### PR TITLE
Fixed an unstable version

### DIFF
--- a/terraform_compliance/common/pyhcl_helper.py
+++ b/terraform_compliance/common/pyhcl_helper.py
@@ -2,6 +2,7 @@ from sys import exc_info, exit
 from os.path import isdir
 from terraform_compliance import Validator
 from terraform_validate.terraform_validate import TerraformSyntaxException
+from shutil import rmtree
 
 
 def load_tf_files(tf_directory):
@@ -9,9 +10,7 @@ def load_tf_files(tf_directory):
     print('Reading terraform files.')
 
     if isdir('{}/.terraform'.format(tf_directory)):
-        print('ERROR: You already have a .terraform directory within your terraform files.')
-        print('       This will lead to run tests against those imported modules. Please delete the directory to continue.')
-        exit(2)
+        rmtree('{}/.terraform'.format(tf_directory))
 
     while result is False:
         try:

--- a/terraform_compliance/common/readable_dir.py
+++ b/terraform_compliance/common/readable_dir.py
@@ -4,12 +4,18 @@ from argparse import Action
 
 
 class ReadableDir(Action):
-    def __init__(self, dest, required, help, option_strings=None, metavar=None):
-        super(ReadableDir, self).__init__(dest, required, help, option_strings, metavar)
+    def __init__(self, option_strings, dest, nargs=None, const=None, default=None, type=None, choices=None,
+                       required=False, help=None, metavar=None):
+        # super(ReadableDir, self).__init__(**kwargs) # dest, required, help, option_strings, metavar)
+        self.option_strings = option_strings
         self.dest = dest
+        self.nargs = nargs
+        self.const = const
+        self.default = default
+        self.type = type
+        self.choices = choices
         self.required = required
         self.help = help
-        self.option_strings = option_strings
         self.metavar = metavar
 
     def __call__(self, parser, namespace, values, option_string=None):

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -10,7 +10,7 @@ from terraform_compliance.common.readable_dir import ReadableDir
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 
 class ArgHandling(object):
@@ -26,7 +26,8 @@ def cli():
     parser.add_argument("--features", "-f", dest="features", metavar='feature_directory', action=ReadableDir,
                         help="Directory consists of BDD features", required=True)
     parser.add_argument("--tfdir", "-t", dest="tf_dir", metavar='terraform_directory', action=ReadableDir,
-                        help="Directory (or git repository with 'git:' prefix) consists of Terraform Files", required=True)
+                        help="Directory (or git repository with 'git:' prefix) consists of Terraform Files",
+                        required=True)
     parser.add_argument("--version", "-v", action="version", version=__version__)
 
     _, radish_arguments = parser.parse_known_args(namespace=argument)
@@ -60,6 +61,7 @@ def cli():
     print('TF Files : {} ({})'.format(tf_directory, argument.tf_dir))
 
     commands = ['radish',
+                '--write-steps-once',
                 features_directory,
                 '--basedir', steps_directory,
                 '--user-data=tf_dir={}'.format(tf_directory)]

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -20,7 +20,7 @@ class ArgHandling(object):
 #TODO: Extend git: (on features or tf files argument) into native URLs instead of using a prefix here.
 
 def cli():
-    argument = ArgHandling()
+    args = ArgHandling()
     parser = ArgumentParser(prog=__app_name__,
                             description="BDD Test Framework for Hashicorp terraform")
     parser.add_argument("--features", "-f", dest="features", metavar='feature_directory', action=ReadableDir,
@@ -30,7 +30,7 @@ def cli():
                         required=True)
     parser.add_argument("--version", "-v", action="version", version=__version__)
 
-    _, radish_arguments = parser.parse_known_args(namespace=argument)
+    _, radish_arguments = parser.parse_known_args(namespace=args)
 
     print('{} v{} initiated'.format(__app_name__, __version__))
 
@@ -38,27 +38,27 @@ def cli():
     print('Steps    : {}'.format(steps_directory))
 
     # A remote repository used here
-    if argument.features.startswith('http'):
-        features_git_repo = argument.features
-        argument.features = mkdtemp()
-        Repo.clone_from(features_git_repo, argument.features)
-    features_directory = os.path.join(os.path.abspath(argument.features))
+    if args.features.startswith('http'):
+        features_git_repo = args.features
+        args.features = mkdtemp()
+        Repo.clone_from(features_git_repo, args.features)
+    features_directory = os.path.join(os.path.abspath(args.features))
     print('Features : {}{}'.format(features_directory, (' ({})'.format(features_git_repo) if 'features_git_repo' in locals() else '')))
 
     tf_tmp_dir = mkdtemp()
 
     # A remote repository is used here.
-    if argument.tf_dir.startswith('http'):
-        tf_git_repo = argument.tf_dir
+    if args.tf_dir.startswith('http'):
+        tf_git_repo = args.tf_dir
         Repo.clone_from(tf_git_repo, tf_tmp_dir)
 
     # A local directory is used here
     else:
         # Copy the given local directory to another place, since we may change some tf files for compatibility.
-        copy_tree(argument.tf_dir, tf_tmp_dir)
+        copy_tree(args.tf_dir, tf_tmp_dir)
 
     tf_directory = os.path.join(os.path.abspath(tf_tmp_dir))
-    print('TF Files : {} ({})'.format(tf_directory, argument.tf_dir))
+    print('TF Files : {} ({})'.format(tf_directory, args.tf_dir))
 
     commands = ['radish',
                 '--write-steps-once',

--- a/tests/terraform_compliance/test_main.py
+++ b/tests/terraform_compliance/test_main.py
@@ -11,7 +11,7 @@ class TestMain(TestCase):
             pass
 
         resp = ReadableDir('parser', 'value', 'git:value').__call__('parser', Namespace, 'git:value')
-        self.assertEqual(Namespace.parser, 'value')
+        self.assertEqual(Namespace.value, 'value')
         self.assertTrue(resp)
 
 
@@ -30,7 +30,7 @@ class TestMain(TestCase):
             pass
 
         resp = ReadableDir('parser', 'value', 'value').__call__('parser', Namespace, 'value')
-        self.assertEqual(Namespace.parser, 'value')
+        self.assertEqual(Namespace.value, 'value')
         self.assertTrue(resp)
 
     @patch.object(os.path, 'isdir', return_value=True)


### PR DESCRIPTION
There was a problem on `0.3.7` on application initiation where it was forgotten for a specific case. In `0.3.8` it is fixed and working properly. 

*`0.3.7` was not working at all!*

Fixed several cases in steps where reading a value via regex and drilling down into the tf configuration was failing when drilled down entity is either a Resource or Property. 