### PR TITLE
BUGFIX: Fixed the issue where terraform-compliance was hanging 

### DIFF
--- a/terraform_compliance/common/exceptions.py
+++ b/terraform_compliance/common/exceptions.py
@@ -1,0 +1,4 @@
+
+
+class TerraformComplianceInvalidConfig(Exception):
+    pass

--- a/terraform_compliance/common/pyhcl_helper.py
+++ b/terraform_compliance/common/pyhcl_helper.py
@@ -25,7 +25,7 @@ def load_tf_files(tf_directory):
             exit(1)
 
         except TerraformSyntaxException:
-            result = pad_invalid_tf_files(exc_info()[1]) is False
+            result = pad_invalid_tf_files(exc_info()[1]) is True
 
         except TerraformComplianceInvalidConfig:
             pass
@@ -48,4 +48,4 @@ def pad_invalid_tf_files(exception_message):
 
 def pad_tf_file(file):
     with open(file, 'a') as f:
-        f.write('variable {}')
+        f.write('\n\nvariable {}')

--- a/tests/terraform_compliance/common/test_pyhcl_helper.py
+++ b/tests/terraform_compliance/common/test_pyhcl_helper.py
@@ -16,7 +16,7 @@ class TestPyHCLHelper(TestCase):
         pad_tf_file(tmpFile)
         contents = open(tmpFile, 'r').read()
         remove(tmpFile)
-        self.assertEqual(contents, 'variable {}')
+        self.assertEqual(contents, '\n\nvariable {}')
 
     @patch('terraform_compliance.common.pyhcl_helper.pad_tf_file', return_value=None)
     def test_pad_invalid_tf_files(self, *args):


### PR DESCRIPTION
- Added better exception handling especially when terraform files have invalid configuration in it.
- Fixes #46, reported by @joshpavel, thanks!
- Bumped up patch version by 1.