### PR TITLE
Fixes a problem where tags are not working properly

### DIFF
--- a/terraform_compliance/common/exceptions.py
+++ b/terraform_compliance/common/exceptions.py
@@ -1,0 +1,4 @@
+
+
+class TerraformComplianceInvalidConfig(Exception):
+    pass

--- a/terraform_compliance/common/pyhcl_helper.py
+++ b/terraform_compliance/common/pyhcl_helper.py
@@ -25,7 +25,7 @@ def load_tf_files(tf_directory):
             exit(1)
 
         except TerraformSyntaxException:
-            result = pad_invalid_tf_files(exc_info()[1]) is False
+            result = pad_invalid_tf_files(exc_info()[1]) is True
 
         except TerraformComplianceInvalidConfig:
             pass
@@ -48,4 +48,4 @@ def pad_invalid_tf_files(exception_message):
 
 def pad_tf_file(file):
     with open(file, 'a') as f:
-        f.write('variable {}')
+        f.write('\n\nvariable {}')

--- a/terraform_compliance/common/pyhcl_helper.py
+++ b/terraform_compliance/common/pyhcl_helper.py
@@ -4,6 +4,7 @@ from terraform_compliance import Validator
 from terraform_validate.terraform_validate import TerraformSyntaxException
 from terraform_compliance.common.exceptions import TerraformComplianceInvalidConfig
 from shutil import rmtree
+from hcl import loads
 
 
 def load_tf_files(tf_directory):
@@ -49,3 +50,16 @@ def pad_invalid_tf_files(exception_message):
 def pad_tf_file(file):
     with open(file, 'a') as f:
         f.write('\n\nvariable {}')
+
+
+def parse_hcl_value(hcl_string):
+    if str(hcl_string).startswith(('${', '"${')):
+        hcl = "key = \"{}\"".format(str(hcl_string).replace("'", "\"").lower())
+
+        try:
+            hcl = loads(hcl)
+            return eval(hcl['key'].replace('${', '{'))
+        except ValueError:
+            return hcl_string
+
+    return hcl_string

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 
 class ArgHandling(object):

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -3,6 +3,7 @@
 from radish import step, world, custom_type, given
 from terraform_compliance.steps import resource_name, encryption_property
 from terraform_compliance.common.helper import check_sg_rules
+from terraform_compliance.common.pyhcl_helper import parse_hcl_value
 from terraform_compliance.extensions.terraform_validate import normalise_tag_values
 from terraform_validate.terraform_validate import TerraformPropertyList, TerraformResourceList
 import re
@@ -92,12 +93,14 @@ def it_condition_contain_something(step, condition, something,
 
     if step.context.stash.__class__ is propertylist:
         for property in step.context.stash.properties:
-            assert property.property_value == something, \
+            value = parse_hcl_value(property.property_value)
+
+            assert (value == something or something.lower() in value), \
                 '{} property in {} can not be found in {} ({}). It is set to {} instead'.format(something,
                                                                                                 property.property_name,
                                                                                                 property.resource_name,
                                                                                                 property.resource_type,
-                                                                                                property.property_value)
+                                                                                                value)
 
     elif step.context.stash.__class__ is resourcelist:
         if condition == 'must':

--- a/tests/terraform_compliance/common/test_pyhcl_helper.py
+++ b/tests/terraform_compliance/common/test_pyhcl_helper.py
@@ -16,7 +16,7 @@ class TestPyHCLHelper(TestCase):
         pad_tf_file(tmpFile)
         contents = open(tmpFile, 'r').read()
         remove(tmpFile)
-        self.assertEqual(contents, 'variable {}')
+        self.assertEqual(contents, '\n\nvariable {}')
 
     @patch('terraform_compliance.common.pyhcl_helper.pad_tf_file', return_value=None)
     def test_pad_invalid_tf_files(self, *args):

--- a/tests/terraform_compliance/common/test_pyhcl_helper.py
+++ b/tests/terraform_compliance/common/test_pyhcl_helper.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 from terraform_compliance.common.pyhcl_helper import (
     load_tf_files,
     pad_invalid_tf_files,
-    pad_tf_file
+    pad_tf_file,
+    parse_hcl_value
 )
 from tests.mocks import MockedValidator
 from os import remove, path, environ
@@ -48,3 +49,7 @@ class TestPyHCLHelper(TestCase):
     def test_load_tf_files_success(self, *args):
         self.assertTrue(load_tf_files('passed'))
         self.assertTrue(environ.get('MockedValidator.state', None) is None)
+
+
+    def test_parse_hcl_value_return_same(self):
+        self.assertEqual(parse_hcl_value('some_string'), 'some_string')


### PR DESCRIPTION
On scenarios where 

```
... it <condition> contains <something>
```

is used, if the data is being processed is an HCL value, this PR will parse that value and additionally search for `<something>` existing within the keys of that value.

This PR addresses the issue reported in #48 