### PR TITLE
Skipping, new informations and general integrity fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 ## Table of Contents
 - [Usage](#usage)
 - [Features](#features)
+- [BDD Directives](#BDD Directives)
 - [Sample Test Set](#Examples)
 - [FAQ](#faq)
 
@@ -47,7 +48,6 @@
 ## Quick Overview
 - __compliance:__ Test your infrastructure as code before you deploy. Enforce your people to follow the policies.
 - __behaviour driven development:__ We have BDD for nearly everything, why not for IaC ?
-- __fixed steps:__ fixed steps coming with the package, just focus on your BDD feature/scenario files.
 - __portable:__ just install it from `pip` or run it via `docker`
 - __why ?:__ why not ?
 
@@ -97,6 +97,8 @@ Ideally, the tools needs to be integrated with a CI/CD tool and runs on every bu
 `terraform-compliance` does not require and infrastructure or credentials to run. It runs against HCL code, thus it is a
 **PRE** compliance tool. In CI/CD pipeline it is recommended to be placed before you create the environment.
 
+The demo shown below is a bit outdated, since lots of things change and tools has been improved substantially since 0.0.1 :)
+The demo will be updated soon ;
 ![Example Run](terraform-compliance-demo.gif)
 ```bash
 [~] $ terraform-compliance -f example/example_01 -t example/tf_files
@@ -156,6 +158,137 @@ Feature: Subnets should be defined properly for network security  # /path/to/exa
 1
 [~] $
 ```
+
+### BDD Directives
+Every BDD feature file will have ;
+
+- Feature
+- Scenario/Scenario Outline
+- Steps
+
+##### Feature
+This draws the overall picture of the feature file that may consist several scenarios.
+
+For e.g. ;
+
+```cucumber
+Feature: Security Groups should be used to protect services/instances
+  In order to improve security
+  As engineers
+  We'll use AWS Security Groups as a Perimeter Defence
+```
+
+This won't effect anything about the test steps, but it will ease the pain for everybody to understand what does that feature aims for.
+
+##### Scenario
+Every feature might have multiple scenarios. A scenario will define a test that might include multiple steps with BDD directives like ;
+
+- GIVEN
+- WHEN
+- THEN
+
+and every step might also have an additional extension step starting with ;
+- AND
+
+There are two types of Scenario ;
+
+- Scenario : Used for defining a scenario without any multiple dynamic variables.
+- Scenario Outline : Used for defining a scenario loops by giving multiple dynamic variables.
+
+##### Steps
+Steps are the functional tests that is actually executing necessary task to validate if the test is successful or not.
+
+`terraform-compliance` has fixed steps already defined within the tool. It is possible to drill down your terraform resources by using these fixed steps.
+
+###### Available Steps
+
+| BDD Conditions | Step Sentence | Parameters | 
+| ---------------| --------------| ---------- |
+| GIVEN          | I have `{name}` `{type}` configured | `name`: name of the key in terraform (e.g. `aws_security_group`, `aws` ) <br>`type`: The type of the key (e.g. `resource`, `provider` etc.) |
+| GIVEN          | I have `{resource_name}` defined | `name`: name of the resource ( e.g. `aws_security_group` ) |
+| WHEN           | I `{math_formula}` them | `math_formula`: `sum` or `count` |
+| THEN           | I expect the result is `{operator}` than `{number}` | `operator`: `more`, `more and equal`, `less`, `less and equal`<br>`number`: an integer |
+| WHEN<br>THEN   | it contain `{something}`<br>it contains `{something}`<br>it must contain `{something}` | `something`: any property within terraform resoruce/provider/etc. (e.g. `access_key`, `ingress` ) |
+| THEN           | encryption is enabled<br>encryption must be enabled | |
+| THEN           | its value `{condition}` match the "`{search_regex}`" regex | `condition`: `must` or `must not`<br>`search_regex`: the regular expression of the searching value |
+| WHEN<br>THEN   | its value must be set by a variable | |
+| THEN           | it must not have `{proto}` protocol and port `{port}` for `{cidr}` | `proto`: tcp, udp<br>`port`: integer port number<br>`cidr`: IP/Cidr |
+
+Every condition can also be used to drill down more in the terraform code by utilising `AND` directive.
+
+Any step consisting `GIVEN` and `WHEN` directives will lead to skip the whole scenario if one of those steps fails. `THEN` directive does not lead any scenario/step skipping, so if the step fails, whole scenario fails.
+
+For e.g. ;
+```cucumber
+  Scenario: TLS enforcement on ELB resources
+    Given I have AWS ELB resource defined
+    When it contains listener
+    Then it must contain ssl_certificate_id
+```
+
+To explain this, it is better to explain this by checking an example terraform code ;
+
+```
+resource "aws_elb" "some_elb" {
+    name            = "My gorgeous ELB name"
+    subnets         = "${var.subnet_ids}"
+    security_groups = ["${aws_security_group.some_elb_sg.id}"]
+
+    listener {
+        instance_port      = 8084
+        instance_protocol  = "https"
+        lb_port            = 8084
+        lb_protocol        = "https"
+        ssl_certificate_id = "${module.acm-cert-elb.acm_cert_arn}"
+    }
+}
+```
+We are trying to create an AWS ELB Instance with SSL Certificates created from a module. 
+The test steps will first run ;
+
+```cucumber
+Given I have AWS ELB resource defined
+```
+which will locate the resorce named `aws_elb` among all other resources ( please have a look [Naming Conventions](Naming Conventions) if you are not sure how `AWS ELB` transformed into `aws_elb` ) and then push the data to the step below ;
+
+```cucumber
+When it contains listener
+```
+
+Then it will drill down the `listener` definition within the HCL. If found, then the data within `listener` will be pushed on the next step.
+
+*Till this point, if any of the steps fail, the further steps will be SKIPPED.*
+
+For the last step ;
+```cucumber
+Then it must contain ssl_certificate_id
+```
+Here it will check within the data coming from the parent step if there is `ssl_certificate_id` defined within. This step is critical since it defines if the scenario will fail or pass.
+
+###### Scenario Loops
+
+It is also possible to use scenario loops. Please note that, `Scenario Outline` needs to be used instead of `Scenario`
+.
+
+```
+Scenario Outline: Well-known insecure protocol exposure on Public Network for ingress traffic
+    Given I have AWS Security Group defined
+  	When it contains ingress
+    Then it must not have <proto> protocol and port <portNumber> for 0.0.0.0/0
+
+  Examples:
+    | ProtocolName | proto | portNumber |
+    | HTTP         | tcp   | 443       |
+    | Telnet       | tcp   | 23         |
+    | SSH          | tcp   | 22         |
+    | MySQL        | tcp   | 3306       |
+    | MSSQL        | tcp   | 1443       |
+    | NetBIOS      | tcp   | 139        |
+    | RDP          | tcp   | 3389       |
+    | Jenkins Slave| tcp   | 50000      |
+```
+
+
 
 ### Examples
 Just as a sample to show the capabilities, `terraform-compliance` repository includes [a sample of tests](https://github.com/eerkunt/terraform-compliance/tree/master/example/example_01/aws).

--- a/example/example_01/aws/credentials.feature
+++ b/example/example_01/aws/credentials.feature
@@ -5,8 +5,8 @@ Feature:Credentials should not be within the code
     
 Scenario Outline: AWS Credentials should not be hardcoded
     Given I have aws provider configured
-    Then it should contain <key>
-    And its value must not match the "<regex>" regex
+    When it contains <key>
+    Then its value must not match the "<regex>" regex
 
     Examples:
     | key        | regex                                                      |

--- a/example/example_01/aws/encryption_in_flight.feature
+++ b/example/example_01/aws/encryption_in_flight.feature
@@ -5,5 +5,5 @@ Feature: Resources that exposes to external networks should have encryption in f
 
   Scenario: TLS enforcement on ELB resources
     Given I have AWS ELB resource defined
-    Then it must contain listener
-    And it must contain ssl_certificate_id
+    When it contains listener
+    Then it must contain ssl_certificate_id

--- a/example/example_01/aws/naming_standards.feature
+++ b/example/example_01/aws/naming_standards.feature
@@ -5,8 +5,8 @@ Feature: Resources should have a proper naming standard
 
   Scenario Outline: Naming Standard on all available resources
     Given I have <resource_name> defined
-    Then it should contain <name_key>
-    And its value must match the "\${var.project}-\${var.environment}-\${var.application}-.*" regex
+    When it contains <name_key>
+    Then its value must match the "\${var.project}-\${var.environment}-\${var.application}-.*" regex
 
     Examples:
     | resource_name           | name_key |

--- a/example/example_01/aws/security_groups.feature
+++ b/example/example_01/aws/security_groups.feature
@@ -13,12 +13,12 @@ Feature: Security Groups should be used to protect services/instances
 
   Scenario Outline: Well-known insecure protocol exposure on Public Network for ingress traffic
     Given I have AWS Security Group defined
-  	And it should contain ingress
+  	When it contains ingress
     Then it must not have <proto> protocol and port <portNumber> for 0.0.0.0/0
 
   Examples:
     | ProtocolName | proto | portNumber |
-    | HTTP         | tcp   | 80         |
+    | HTTP         | tcp   | 443       |
     | Telnet       | tcp   | 23         |
     | SSH          | tcp   | 22         |
     | MySQL        | tcp   | 3306       |

--- a/example/example_01/aws/tags.feature
+++ b/example/example_01/aws/tags.feature
@@ -3,10 +3,14 @@ Feature: Resources should be properly tagged
   As engineers
   We'll enforce tagging on all resources
 
-  Scenario Outline: Name tag
+  Scenario: Ensure all resources have tags
     Given I have resource that supports tags defined
     Then it must contain tags
-    And it must contain <tags>
+
+  Scenario Outline: Ensure that specific tags are defined
+    Given I have resource that supports tags defined
+    When it contains tags
+    Then it must contain <tags>
 
   Examples:
   | tags        |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 terraform_validate==2.8.0
 radish==0.1.10
-radish-bdd==0.8.6
+radish-bdd==0.10.0
 gitpython==2.1.10
 mock==2.0.0
 netaddr==0.7.19
+colorful==0.4.4

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -4,6 +4,7 @@ from netaddr import IPNetwork
 
 hcl_conditions = ["==", "!=", ">", "<", ">=", "<=", "&&", "||", "!"]
 
+
 # A helper function that will be used to flatten a multi-dimensional multi-nested list
 def flatten_list(input):
     new_list = []
@@ -83,6 +84,7 @@ def check_sg_rules(tf_conf, security_group, proto, port, cidr):
 
     validate_sg_rule(proto=proto, port=port, cidr=cidr, params=assign_sg_params(security_group))
 
+
 def assign_sg_params(rule):
     from_port = int(rule.get('from_port', 0))
     to_port = int(rule.get('to_port', 0))
@@ -117,6 +119,7 @@ def validate_sg_rule(proto, port, cidr, params):
     port = int(port)
     if port >= params['from_port'] and port <= params['to_port'] and proto in params['protocol'] and is_ip_in_cidr(cidr, params['cidr_blocks']):
         raise AssertionError('Found {}/{} in {}/{}-{} for {}'.format(proto, port, params['protocol'], params['from_port'], params['to_port'], params['cidr_blocks']))
+
 
 def change_value_in_dict(target_dictionary, path_to_change, value_to_change):
     if type(path_to_change) is str:
@@ -158,6 +161,7 @@ def change_value_in_dict(target_dictionary, path_to_change, value_to_change):
 
     except KeyError:
         pass
+
 
 def strip_conditions(string):
     for condition in hcl_conditions:

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -68,10 +68,16 @@ def check_sg_rules(tf_conf, security_group, proto, port, cidr):
         if type(security_group['cidr_blocks']) is list:
             for i in range(0,len(security_group['cidr_blocks'])):
                 if not check_if_cidr(security_group['cidr_blocks'][i]):
-                    security_group['cidr_blocks'][i] = expand_variable(tf_conf, security_group['cidr_blocks'][i])['default']
+                    security_group['cidr_blocks'][i] = expand_variable(tf_conf,
+                                                                       security_group['cidr_blocks'][i]
+                                                                       ).get('default',
+                                                                             security_group['cidr_blocks'][i])
         else:
             if not check_if_cidr(security_group['cidr_blocks']):
-                security_group['cidr_blocks'] = expand_variable(tf_conf, security_group['cidr_blocks'])['default']
+                security_group['cidr_blocks'] = expand_variable(tf_conf,
+                                                                security_group['cidr_blocks']
+                                                                ).get('default',
+                                                                      security_group['cidr_blocks'])
 
 
     validate_sg_rule(proto=proto, port=port, cidr=cidr, params=assign_sg_params(security_group))

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -55,8 +55,9 @@ def check_if_cidr( value ):
 
 def is_ip_in_cidr(ip_cidr, cidr):
     for ip_network in cidr:
-        if IPNetwork(ip_cidr) in IPNetwork(ip_network):
-            return True
+        if check_if_cidr(ip_cidr) and check_if_cidr(ip_network):
+            if IPNetwork(ip_cidr) in IPNetwork(ip_network):
+                return True
 
     return False
 

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -22,6 +22,7 @@ def skip_step(step, resource=None, message=None):
     for each in step.parent.all_steps:
         each.runable = False
 
+
 def step_condition(step):
     current_condition = step.sentence.lower().split(" ")[0]
 
@@ -37,6 +38,7 @@ def step_condition(step):
                         current_condition = parent_step.context_class
 
     return current_condition
+
 
 def write_stdout(level, message):
 

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -9,7 +9,7 @@ def skip_step(step, resource=None, message=None):
     if message is None:
         message = '{} {} {}'.format(colorful.orange('Can not find'),
                                     colorful.magenta(resource),
-                                    colorful.orange('resource defined in target terraform files.'))
+                                    colorful.orange('defined in target terraform files.'))
     else:
         message = colorful.orange(message)
 
@@ -42,11 +42,11 @@ def write_stdout(level, message):
 
     prefix = colorful.bold_yellow('INFO :')
     if level == 'WARNING':
-        prefix = colorful.bold_white_on_red('WARNING :')
+        prefix = colorful.bold_red('WARNING :')
         message = colorful.yellow(message)
 
 
     added_prefix = '\n\t\t{} '.format(' '*len(prefix))
     message = message.split('\n')
 
-    console_write('\n\t\t{} {}\n\n'.format(prefix, added_prefix.join(message)))
+    console_write('\n\t\t{} {}'.format(prefix, added_prefix.join(message)))

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -1,0 +1,19 @@
+import colorful
+from radish.utils import console_write
+
+
+def skip_step(step, resource=None, message=None):
+    step.skip()
+    if resource is None:
+        resource = 'any'
+
+    if message is None:
+        message = '{} {} {}'.format(colorful.orange('Can not find'),
+                                    colorful.magenta(resource),
+                                    colorful.orange('resource defined in target terraform files.'))
+    else:
+        message = colorful.orange(message)
+
+    console_write("\t{}: {}".format(colorful.bold_purple('SKIPPING'),
+                                    message)
+    )

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -3,7 +3,6 @@ from radish.utils import console_write
 
 
 def skip_step(step, resource=None, message=None):
-    step.skip()
     if resource is None:
         resource = 'any'
 
@@ -15,5 +14,26 @@ def skip_step(step, resource=None, message=None):
         message = colorful.orange(message)
 
     console_write("\t{}: {}".format(colorful.bold_purple('SKIPPING'),
-                                    message)
+                                    message.format(resource=colorful.magenta(resource)))
     )
+    step.skip()
+
+    # Skip all steps in the scenario
+    for each in step.parent.all_steps:
+        each.runable = False
+
+def step_condition(step):
+    current_condition = step.sentence.lower().split(" ")[0]
+
+    # if the condition is AND then check for the first previous feature line to determine if it is a
+    # GIVEN, WHEN or THEN
+    if current_condition == "and":
+        step_id = int(step.id)-1
+        if step_id > 0:
+            for parent_step in step.parent.all_steps.reverse():
+                # For the steps that has lower id than ours, so the steps on the above, not below
+                if parent_step.id < step_id:
+                    if parent_step.sentence.lower().split(" ")[0] in ["given", "when", "then"]:
+                        current_condition = parent_step.sentence.lower().split(" ")[0]
+
+    return current_condition

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -40,13 +40,13 @@ def step_condition(step):
 
 def write_stdout(level, message):
 
-    prefix = colorful.bold_yellow('INFO :')
+    prefix = colorful.bold_yellow(u'\u229b INFO :')
     if level == 'WARNING':
-        prefix = colorful.bold_red('WARNING :')
+        prefix = colorful.bold_red(u'\u2757 WARNING :')
         message = colorful.yellow(message)
 
 
-    added_prefix = '\n\t\t{} '.format(' '*len(prefix))
+    added_prefix = u'\n\t\t{}\t{} '.format(colorful.gray(u'\u2502'),' '*len(prefix))
     message = message.split('\n')
 
-    console_write('\n\t\t{} {}'.format(prefix, added_prefix.join(message)))
+    console_write(u'\t\t\u251c\u2501\t{} {}'.format(prefix, added_prefix.join(message)))

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -33,7 +33,20 @@ def step_condition(step):
             for parent_step in step.parent.all_steps.reverse():
                 # For the steps that has lower id than ours, so the steps on the above, not below
                 if parent_step.id < step_id:
-                    if parent_step.sentence.lower().split(" ")[0] in ["given", "when", "then"]:
-                        current_condition = parent_step.sentence.lower().split(" ")[0]
+                    if parent_step.context_class in ["given", "when", "then"]:
+                        current_condition = parent_step.context_class
 
     return current_condition
+
+def write_stdout(level, message):
+
+    prefix = colorful.bold_yellow('INFO :')
+    if level == 'WARNING':
+        prefix = colorful.bold_white_on_red('WARNING :')
+        message = colorful.yellow(message)
+
+
+    added_prefix = '\n\t\t{} '.format(' '*len(prefix))
+    message = message.split('\n')
+
+    console_write('\n\t\t{} {}\n\n'.format(prefix, added_prefix.join(message)))

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.4.13"
+__version__ = "0.5.0"
 
 
 

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -134,6 +134,7 @@ def it_condition_contain_something(step, something,
             step.context.stash = step.context.stash.find_property(something)
             assert step.context.stash.properties, \
                 'No defined property/value found for {}.'.format(something)
+            step.context.stash = step.context.stash.properties
         else:
             try:
                 step.context.stash.should_have_properties(something)
@@ -143,8 +144,9 @@ def it_condition_contain_something(step, something,
                     if number_of_resources > len(step.context.stash.properties):
                         write_stdout(level='INFO',
                                      message='Some of the resources does not have {} property defined within.\n'
-                                             'Removed {} resource from the test scope.\n\n'.format(something,
+                                             'Removed {} resource (out of {}) from the test scope.\n\n'.format(something,
                                                                     (number_of_resources-len(step.context.stash.properties)),
+                                                                                                               number_of_resources,
                                                                     ))
             except Exception as e:
                 number_of_resources = len(step.context.stash.resource_list)
@@ -152,9 +154,10 @@ def it_condition_contain_something(step, something,
                 if step.context.stash:
                     write_stdout(level='INFO',
                                  message='Some of the resources does not have {} property defined within.\n' 
-                                         'Removed {} resource from the test scope.\n\n'
+                                         'Removed {} resource (out of {}) from the test scope.\n\n'
                                          'Due to : \n{}'.format(something,
                                                     (number_of_resources-len(step.context.stash.properties)),
+                                                                number_of_resources,
                                                     str(e)))
                 else:
                     skip_step(step,

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from radish import step, world, custom_type, given
+from radish import step, world, custom_type, given, when
 from terraform_compliance.steps import resource_name, encryption_property
 from terraform_compliance.common.helper import check_sg_rules
 from terraform_compliance.common.pyhcl_helper import parse_hcl_value
 from terraform_compliance.extensions.terraform_validate import normalise_tag_values
 from terraform_validate.terraform_validate import TerraformPropertyList, TerraformResourceList
-from terraform_compliance.extensions.ext_radish_bdd import skip_step
+from terraform_compliance.extensions.ext_radish_bdd import skip_step, step_condition
 import re
 
 # world.config.debug_steps = True
@@ -75,9 +75,9 @@ def i_have_resource_defined(step, resource, radish_world=None):
 
 @step(u'I {action_type:ANY} them')
 def i_action_them(step, action_type):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.skip()
-        return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.skip()
+    #     return
 
     if action_type == "count":
         step.context.stash = len(step.context.stash.resource_list)
@@ -89,9 +89,9 @@ def i_action_them(step, action_type):
 
 @step(u'I expect the result is {operator:ANY} than {number:d}')
 def i_expect_the_result_is_operator_than_number(step, operator, number):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.skip()
-        return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.skip()
+    #     return
 
     value = int(step.context.stash)
 
@@ -106,14 +106,17 @@ def i_expect_the_result_is_operator_than_number(step, operator, number):
     else:
         AssertionError('Invalid operator: {}'.format(operator))
 
-
-@step(u'it {condition:ANY} contain {something:ANY}')
-def it_condition_contain_something(step, condition, something,
+@when(u'it contain {something:ANY}')
+@when(u'it contains {something:ANY}')
+@step(u'it must contain {something:ANY}')
+def it_condition_contain_something(step, something,
                                    propertylist=TerraformPropertyList, resourcelist=TerraformResourceList):
 
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.skip()
-        return
+    step_can_skip = step_condition(step) in ["given", "when"]
+
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.skip()
+    #     return
 
     if step.context.stash.__class__ is propertylist:
         for property in step.context.stash.properties:
@@ -128,7 +131,7 @@ def it_condition_contain_something(step, condition, something,
                                                                                                     value)
 
     elif step.context.stash.__class__ is resourcelist:
-        if condition == 'must':
+        if step_can_skip is False:
             step.context.stash.should_have_properties(something)
 
         if something in resource_name.keys():
@@ -136,23 +139,32 @@ def it_condition_contain_something(step, condition, something,
 
         step.context.stash = step.context.stash.property(something)
 
-        if condition == 'must':
+        if step_can_skip:
+            if not hasattr(step.context.stash, 'properties'):
+                skip_step(step,
+                          resource=something,
+                          message='Can not find any resource properties for {resource} in terraform files')
+        else:
             assert step.context.stash.properties, \
                 '{} doesnt have a property list.'.format(something)
+
     elif step.context.stash.__class__ is dict:
         if something in step.context.stash:
             step.context.stash = step.context.stash[something]
         else:
-            if condition == 'must':
+            if step_can_skip:
+                skip_step(step,
+                          resource=something,
+                          message='Can not find {resource} resource in terraform files.')
+            else:
                 assert False, '{} does not exist.'.format(something)
-
 
 @step(u'encryption is enabled')
 @step(u'encryption must be enabled')
 def encryption_is_enabled(step):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.state = 'skipped'
-        return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.state = 'skipped'
+    #     return
 
     prop = encryption_property[step.context.resource_type]
     step.context.stash.property(prop).should_equal(True)
@@ -160,9 +172,9 @@ def encryption_is_enabled(step):
 
 @step(u'its value {condition} match the "{search_regex}" regex')
 def its_value_condition_match_the_search_regex_regex(step, condition, search_regex):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.skip()
-        return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.skip()
+    #     return
 
     regex = r'{}'.format(search_regex)
 
@@ -209,18 +221,18 @@ def its_value_condition_match_the_search_regex_regex(step, condition, search_reg
 
 @step(u'its value must be set by a variable')
 def its_value_must_be_set_by_a_variable(step):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-        step.skip()
-        return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #     step.skip()
+    #     return
 
     step.context.stash.property(step.context.search_value).should_match_regex(r'\${var.(.*)}')
 
 
 @step(u'it must not have {proto} protocol and port {port:d} for {cidr:ANY}')
 def it_must_not_have_proto_protocol_and_port_port_for_cidr(step, proto, port, cidr):
-    if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
-         step.skip()
-         return
+    # if not hasattr(step.context, 'stash') or (hasattr(step.context.stash, 'resource_list') and not step.context.stash.resource_list):
+    #      step.skip()
+    #      return
 
     proto = str(proto)
     port = int(port)

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -125,7 +125,6 @@ def it_condition_contain_something(step, something,
                                                              property.property_value))
                 step.state = 'skipped'
 
-
     elif step.context.stash.__class__ is resourcelist:
         if step_can_skip is False:
             step.context.stash.should_have_properties(something)

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -68,9 +68,7 @@ def i_have_resource_defined(step, resource, radish_world=None):
     else:
         skip_step(step, '{} resource'.format(resource))
 
-# TODO: Documentation about should and must :( Given and When may lead to skip a scenario, where Then can not.
-
-@step(u'I {action_type:ANY} them')
+@when(u'I {action_type:ANY} them')
 def i_action_them(step, action_type):
     if action_type == "count":
         step.context.stash = len(step.context.stash.resource_list)
@@ -80,7 +78,7 @@ def i_action_them(step, action_type):
         AssertionError("Invalid action_type in the scenario: {}".format(action_type))
 
 
-@step(u'I expect the result is {operator:ANY} than {number:d}')
+@then(u'I expect the result is {operator:ANY} than {number:d}')
 def i_expect_the_result_is_operator_than_number(step, operator, number):
     value = int(step.context.stash)
 
@@ -97,7 +95,7 @@ def i_expect_the_result_is_operator_than_number(step, operator, number):
 
 @when(u'it contain {something:ANY}')
 @when(u'it contains {something:ANY}')
-@step(u'it must contain {something:ANY}')
+@then(u'it must contain {something:ANY}')
 def it_condition_contain_something(step, something,
                                    propertylist=TerraformPropertyList, resourcelist=TerraformResourceList):
 
@@ -175,8 +173,8 @@ def it_condition_contain_something(step, something,
             else:
                 assert False, '{} does not exist.'.format(something)
 
-@step(u'encryption is enabled')
-@step(u'encryption must be enabled')
+@then(u'encryption is enabled')
+@then(u'encryption must be enabled')
 def encryption_is_enabled(step):
     prop = encryption_property[step.context.resource_type]
     step.context.stash.property(prop).should_equal(True)
@@ -232,7 +230,7 @@ def its_value_must_be_set_by_a_variable(step):
     step.context.stash.property(step.context.search_value).should_match_regex(r'\${var.(.*)}')
 
 
-@step(u'it must not have {proto} protocol and port {port:d} for {cidr:ANY}')
+@then(u'it must not have {proto} protocol and port {port:d} for {cidr:ANY}')
 def it_must_not_have_proto_protocol_and_port_port_for_cidr(step, proto, port, cidr):
     proto = str(proto)
     port = int(port)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -319,6 +319,8 @@ class MockedTerraformPropertyList(object):
     def should_equal(self, bool):
         return bool
 
+    def should_match_regex(self, regex):
+        return True
 
 class MockedTerraformProperty(object):
     def __init__(self):
@@ -327,6 +329,8 @@ class MockedTerraformProperty(object):
         self.resource_type = 'test_resource_type'
         self.property_name = 'test_name'
 
+    def should_match_regex(self, regex):
+        return True
 
 class MockedTerraformResourceList(object):
     def __init__(self, type={}):
@@ -340,7 +344,7 @@ class MockedTerraformResourceList(object):
     def property(self, key):
         if key is None:
             raise Exception('property hit')
-        self.properties = [MockedTerraformPropertyList()]
+        self.properties = MockedTerraformPropertyList()
         return self.properties
 
     def should_match_regex(self, regex):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -256,15 +256,24 @@ class MockedValidator(object):
 
 
 class MockedStep(object):
-    def __init__(self):
+    def __init__(self, no_init=None):
         self.context = MockedStepContext()
+        self.sentence = 'Given I am a step'
+
+        if no_init is None:
+            self.parent = MockedParentStep()
 
     def skip(self):
         self.state = 'skipped'
 
+class MockedParentStep(object):
+    def __init__(self):
+        self.all_steps = [MockedStep(no_init=True), MockedStep(no_init=True), MockedStep(no_init=True)]
+
 class MockedStepContext(object):
     def __init__(self):
         self.stash = MockedWorldConfigTerraform()
+        self.resource_type = 'aws_db_instance'
 
 
 class MockedWorld(object):
@@ -294,19 +303,21 @@ class MockedWorldConfigTerraform(object):
                     }
                 }
             },
-
             u'provider': {
                 u'aws': {}
             },
             u'something_else': {'something': 'else'}
         }
     def resources(self, name):
-        return self.terraform_config['resource'][name]
+        return MockedTerraformResourceList(self.terraform_config['resource'][name])
 
 
 class MockedTerraformPropertyList(object):
     def __init__(self):
         self.properties = [MockedTerraformProperty()]
+
+    def should_equal(self, bool):
+        return bool
 
 
 class MockedTerraformProperty(object):
@@ -318,6 +329,10 @@ class MockedTerraformProperty(object):
 
 
 class MockedTerraformResourceList(object):
+    def __init__(self, type={}):
+        self.resource_list = [type]
+        self.properties = [MockedTerraformPropertyList()]
+
     def should_have_properties(self, key):
         if key is None:
             raise Exception('should_have_properties hit')
@@ -325,11 +340,17 @@ class MockedTerraformResourceList(object):
     def property(self, key):
         if key is None:
             raise Exception('property hit')
-        self.properties = MockedTerraformPropertyList()
+        self.properties = [MockedTerraformPropertyList()]
         return self.properties
 
     def should_match_regex(self, regex):
         return True
+
+    def find_property(self, property):
+        if property is None:
+            return None
+
+        return MockedTerraformResourceList()
 
 
 class MockedArgumentParser(object):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -221,6 +221,8 @@ class MockedData(object):
         }
     }
 
+    mocked_tf_issue_52 = ""
+
     # security_groups
     sg_ssh_with_2_cidrs = {u'to_port': 22, u'cidr_blocks': [u'213.86.221.35/32', u'195.99.231.117/32'], u'from_port': 22, u'protocol': u'tcp'}
     sg_ssh_with_2_cidrs_any_proto = {u'to_port': 22, u'cidr_blocks': [u'213.86.221.35/32', u'195.99.231.117/32'], u'from_port': 22, u'protocol': u'-1'}
@@ -256,6 +258,9 @@ class MockedValidator(object):
 class MockedStep(object):
     def __init__(self):
         self.context = MockedStepContext()
+
+    def skip(self):
+        self.state = 'skipped'
 
 class MockedStepContext(object):
     def __init__(self):

--- a/tests/terraform_compliance/extensions/test_ext_radish_bdd.py
+++ b/tests/terraform_compliance/extensions/test_ext_radish_bdd.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from terraform_compliance.extensions.ext_radish_bdd import skip_step, write_stdout, step_condition
+from tests.mocks import MockedStep
+
+class TestRadishBddExtension(TestCase):
+    def test_step_condition(self):
+        step = MockedStep()
+
+        step.sentence = 'Given I do this'
+        self.assertEqual(step_condition(step), 'given')
+
+        step.sentence = 'When I do this'
+        self.assertEqual(step_condition(step), 'when')
+
+        step.sentence = 'Then I do this'
+        self.assertEqual(step_condition(step), 'then')
+
+    def test_write_stdout(self):
+        self.assertEqual(None, write_stdout('info','test'))
+
+    def test_skip_step(self):
+        step = MockedStep()
+        skip_step(step)
+        self.assertEqual(step.state, 'skipped')

--- a/tests/terraform_compliance/steps/test_given_steps.py
+++ b/tests/terraform_compliance/steps/test_given_steps.py
@@ -11,7 +11,7 @@ class Test_Given_Step_Cases(TestCase):
 
     def test_i_have_name_section_configured(self):
         i_have_name_section_configured(self.step, 'resource_type', 'resource', self.radish_world)
-        self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['resource']['resource_type'])
+        self.assertEqual(self.step.context.stash.resource_list[0], MockedWorldConfigTerraform().terraform_config['resource']['resource_type'])
 
         i_have_name_section_configured(self.step, 'aws', 'provider', self.radish_world)
         self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['provider']['aws'])
@@ -20,12 +20,12 @@ class Test_Given_Step_Cases(TestCase):
         self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['something_else'])
 
         i_have_name_section_configured(self.step, 'AWS S3 Bucket', 'resource', self.radish_world)
-        self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['resource']['aws_s3_bucket'])
+        self.assertEqual(self.step.context.stash.resource_list[0], MockedWorldConfigTerraform().terraform_config['resource']['aws_s3_bucket'])
 
     def test_i_have_resource_defined(self):
         i_have_resource_defined(self.step, 'resource_type', self.radish_world)
-        self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['resource']['resource_type'])
+        self.assertEqual(self.step.context.stash.resource_list[0], MockedWorldConfigTerraform().terraform_config['resource']['resource_type'])
 
         i_have_resource_defined(self.step, 'AWS S3 Bucket', self.radish_world)
-        self.assertEqual(self.step.context.stash, MockedWorldConfigTerraform().terraform_config['resource']['aws_s3_bucket'])
+        self.assertEqual(self.step.context.stash.resource_list[0], MockedWorldConfigTerraform().terraform_config['resource']['aws_s3_bucket'])
 

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -107,8 +107,9 @@ class Test_Step_Cases(TestCase):
     def test_it_must_contain_something_property_can_not_be_found(self, *args):
         step = MockedStep()
         step.context.stash = MockedTerraformPropertyList()
+        step.sentence = 'Then it must contain'
         with self.assertRaises(AssertionError) as err:
-            it_condition_contain_something(step, 'should', 'non_existent_property_value', MockedTerraformPropertyList)
+            it_condition_contain_something(step, 'non_existent_property_value', MockedTerraformPropertyList)
         self.assertEqual(str(err.exception), 'non_existent_property_value property in test_name can not be found in ' 
                                              'test_resource_name (test_resource_type). It is set to test_value instead')
 
@@ -129,7 +130,7 @@ class Test_Step_Cases(TestCase):
         step.context.stash = MockedTerraformResourceList()
         step.sentence = 'Then it must ..'
         it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
-        self.assertEqual(step.context.stash.__class__, MockedTerraformPropertyList)
+        self.assertEqual(step.context.stash.[0].__class__, MockedTerraformPropertyList)
 
     def test_it_condition_must_something_property_stash_is_dict_found(self):
         step = MockedStep()
@@ -139,9 +140,15 @@ class Test_Step_Cases(TestCase):
     def test_it_condition_should_something_property_stash_is_dict_found(self):
         step = MockedStep()
         step.context.stash = {}
+        step.sentence = 'Then it must contain'
         with self.assertRaises(AssertionError) as err:
             it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
         self.assertEqual(str(err.exception), 'something does not exist.')
+
+        step.sentence = 'When it contains'
+        step.context.stash = {}
+        it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
+        self.assertEqual(step.state, 'skipped')
 
     def test_encryption_is_enabled_resource_list(self):
         step = MockedStep()
@@ -150,7 +157,7 @@ class Test_Step_Cases(TestCase):
 
     def test_its_value_condition_match_the_search_regex_regex_resource_list(self):
         step = MockedStep()
-        step.context.stash.resource_list = None
+        step.context.stash = MockedTerraformPropertyList()
         self.assertIsNone(its_value_condition_match_the_search_regex_regex(step, 'condition', 'some_regex'))
 
     def test_its_value_must_match_the_search_regex_regex_string_unicode_success(self):
@@ -211,7 +218,8 @@ class Test_Step_Cases(TestCase):
 
     def test_its_value_must_be_set_by_a_variable_resource_list(self):
         step = MockedStep()
-        step.context.stash.resource_list = None
+        step.context.stash = MockedTerraformResourceList()
+        step.context.search_value = 'something'
         self.assertIsNone(its_value_must_be_set_by_a_variable(step))
 
     @patch.object(MockedTerraformResourceList, 'property', return_value=MockedTerraformResourceList())

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -40,7 +40,7 @@ class Test_Step_Cases(TestCase):
 
     def test_i_expect_the_result_is_operator_than_number_resource_list_as_dict(self):
         step = MockedStep()
-        step.context.stash.resource_list = None
+        step.context.stash = 42
         self.assertIsNone(i_expect_the_result_is_operator_than_number(step, 'operator', 'not_important'))
 
     def test_i_expect_the_result_is_more_than_number_success(self):
@@ -104,7 +104,7 @@ class Test_Step_Cases(TestCase):
         self.assertIsNone(it_condition_contain_something(step, 'should', 'not_important'))
 
     @patch('terraform_compliance.steps.steps.world', side_effect=MockedWorld())
-    def test_it_condition_contain_something_property_can_not_be_found(self, *args):
+    def test_it_must_contain_something_property_can_not_be_found(self, *args):
         step = MockedStep()
         step.context.stash = MockedTerraformPropertyList()
         with self.assertRaises(AssertionError) as err:
@@ -115,31 +115,37 @@ class Test_Step_Cases(TestCase):
     def test_it_condition_must_something_property_can_not_be_found(self):
         step = MockedStep()
         step.context.stash = MockedTerraformResourceList()
+        step.sentence = 'Then it must ..'
         with self.assertRaises(Exception) as err:
-            it_condition_contain_something(step=step, condition='must', something=None, resourcelist=MockedTerraformResourceList)
+            it_condition_contain_something(step=step, something=None, resourcelist=MockedTerraformResourceList)
         self.assertEqual(str(err.exception), 'should_have_properties hit')
+
+        step.sentence = 'When it contains'
+        it_condition_contain_something(step=step, something=None, resourcelist=MockedTerraformResourceList)
+        self.assertEqual(step.state, 'skipped')
 
     def test_it_condition_must_something_property_is_found(self):
         step = MockedStep()
         step.context.stash = MockedTerraformResourceList()
-        it_condition_contain_something(step=step, condition='must', something='something', resourcelist=MockedTerraformResourceList)
+        step.sentence = 'Then it must ..'
+        it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
         self.assertEqual(step.context.stash.__class__, MockedTerraformPropertyList)
 
     def test_it_condition_must_something_property_stash_is_dict_found(self):
         step = MockedStep()
         step.context.stash = {'something': 'something else'}
-        self.assertIsNone(it_condition_contain_something(step=step, condition='must', something='something', resourcelist=MockedTerraformResourceList))
+        self.assertIsNone(it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList))
 
     def test_it_condition_should_something_property_stash_is_dict_found(self):
         step = MockedStep()
         step.context.stash = {}
         with self.assertRaises(AssertionError) as err:
-            it_condition_contain_something(step=step, condition='must', something='something', resourcelist=MockedTerraformResourceList)
+            it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
         self.assertEqual(str(err.exception), 'something does not exist.')
 
     def test_encryption_is_enabled_resource_list(self):
         step = MockedStep()
-        step.context.stash.resource_list = None
+        step.context.stash = MockedTerraformResourceList()
         self.assertIsNone(encryption_is_enabled(step))
 
     def test_its_value_condition_match_the_search_regex_regex_resource_list(self):

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -130,7 +130,7 @@ class Test_Step_Cases(TestCase):
         step.context.stash = MockedTerraformResourceList()
         step.sentence = 'Then it must ..'
         it_condition_contain_something(step=step, something='something', resourcelist=MockedTerraformResourceList)
-        self.assertEqual(step.context.stash.[0].__class__, MockedTerraformPropertyList)
+        self.assertEqual(step.context.stash[0].__class__, MockedTerraformPropertyList)
 
     def test_it_condition_must_something_property_stash_is_dict_found(self):
         step = MockedStep()


### PR DESCRIPTION
This release will address problems reported in ;
- #58 
- #57 

It also includes ;
- General stability and integrity refactoring
- Scenario skipping where if`GIVEN` and `WHEN` failed during the tests, further steps won't be run. 
- Additional information about failures, scenario skips or resource filtering cases.
- Additional documentation ( although I will create a separate web page for the tool soon ) about steps, general structure and list of the steps that are available with examples
- Upstream functionality fix on `radish-bdd` that leads library upgrade from `0.8.6` to `0.10.0` within the tool.
- All examples updated based on the new step structure

**THIS VERSION MAY NOT BE COMPATIBLE WITH 0.4 VERSIONS**
Some of the step definitions and style of drilling down the terraform code might require some changes - depending on your feature files. Please consult documentation within `README.md`