### PR TITLE
New Feature - Security Group Rule It must only have condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Steps are the functional tests that is actually executing necessary task to vali
 | THEN           | encryption is enabled<br>encryption must be enabled | |
 | THEN           | its value `{condition}` match the "`{search_regex}`" regex | `condition`: `must` or `must not`<br>`search_regex`: the regular expression of the searching value |
 | WHEN<br>THEN   | its value must be set by a variable | |
-| THEN           | it must not have `{proto}` protocol and port `{port}` for `{cidr}` | `proto`: tcp, udp<br>`port`: integer port number (or a port range by using `-` delimeter between port ranges [e.g. 80-84])<br>`cidr`: IP/Cidr |
+| THEN           | it must `{condition}` have `{proto}` protocol and port `{port}` for `{cidr}` | `{condition}`: only,not<br>`proto`: tcp, udp<br>`port`: integer port number (or a port range by using `-` delimeter between port ranges [e.g. 80-84])<br>`cidr`: IP/Cidr |
 
 Every condition can also be used to drill down more in the terraform code by utilising `AND` directive.
 

--- a/example/example_01/aws/security_groups.feature
+++ b/example/example_01/aws/security_groups.feature
@@ -16,6 +16,7 @@ Feature: Security Groups should be used to protect services/instances
   	When it contains ingress
     Then it must not have <proto> protocol and port <portNumber> for 0.0.0.0/0
 
+
   Examples:
     | ProtocolName | proto | portNumber |
     | HTTP         | tcp   | 443       |
@@ -27,9 +28,12 @@ Feature: Security Groups should be used to protect services/instances
     | RDP          | tcp   | 3389       |
     | Jenkins Slave| tcp   | 50000      |
 
-
   Scenario: No publicly open ports
     Given I have AWS Security Group defined
     When it contains ingress
     Then it must not have tcp protocol and port 1024-65535 for 0.0.0.0/0
 
+  Scenario: Only selected ports should be publicly open
+    Given I have AWS Security Group defined
+    When it contains ingress
+    Then it must only have tcp protocol and port 22,443 for 0.0.0.0/0

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -129,7 +129,7 @@ def validate_sg_rule(should_present, proto, from_port, to_port, ports, cidr, par
     if should_present:
         in_string = 'not in'
         given_range = set([int(port) for port in ports])
-        intersection = given_range & defined_range
+        intersection = not(given_range & defined_range)
         from_to_port = ','.join(ports)
     else:
         in_string = 'in'

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -116,7 +116,14 @@ def assign_sg_params(rule):
 
 
 def validate_sg_rule(should_present, proto, from_port, to_port, ports, cidr, params):
+    from_port = int(from_port)
+    to_port = int(to_port)
 
+    assert from_port <= to_port, 'Port range is defined incorrectly within the Scenario. ' \
+                                 'Define it {}-{} instead of {}-{}.'.format(from_port,
+                                                                            to_port,
+                                                                            to_port,
+                                                                            from_port)
     defined_range = set(range(params['from_port'], params['to_port']+1))
 
     if should_present:
@@ -125,20 +132,12 @@ def validate_sg_rule(should_present, proto, from_port, to_port, ports, cidr, par
         intersection = given_range & defined_range
         from_to_port = ','.join(ports)
     else:
-        from_port = int(from_port)
-        to_port = int(to_port)
-    
-        assert from_port <= to_port, 'Port range is defined incorrectly within the Scenario. ' \
-                                     'Define it {}-{} instead of {}-{}.'.format(from_port,
-                                                                                to_port,
-                                                                                to_port,
-                                                                                from_port)
         in_string = 'in'
         given_range = set(range(from_port, to_port+1))
-        intersection = not(given_range & defined_range)
+        intersection = given_range & defined_range
         from_to_port = str(from_port) + '-' + str(to_port)
 
-    if not intersection and is_ip_in_cidr(cidr, params['cidr_blocks']):
+    if intersection and is_ip_in_cidr(cidr, params['cidr_blocks']):
         raise AssertionError("Port {}/{} {} {}/{} for {}".format(
                 proto,
                 '{}-{}'.format(params['from_port'], params['to_port']),

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 
 

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -23,6 +23,10 @@ def custom_type_section(text):
     if text in ['resource', 'provider', 'data', 'module', 'output', 'terraform', 'variable']:
         return text
 
+@custom_type("CONDITION", r"[a-z]+")
+def custom_type_condition(text):
+    if text in ['only', 'not']:
+        return text
 
 @given(u'I have {name:ANY} {type_name:SECTION} configured')
 def i_have_name_section_configured(step_obj, name, type_name, radish_world=None):
@@ -240,7 +244,7 @@ def its_value_must_be_set_by_a_variable(step_obj):
     step_obj.context.stash.property(step_obj.context.search_value).should_match_regex(r'\${var.(.*)}')
 
 
-@then(u'it {condition:ANY} have {proto:ANY} protocol and port {port} for {cidr:ANY}')
+@then(u'it must {condition:ANY} have {proto:ANY} protocol and port {port} for {cidr:ANY}')
 def it_condition_have_proto_protocol_and_port_port_for_cidr(step_obj, condition, proto, port, cidr):
     proto = str(proto)
     cidr = str(cidr)
@@ -251,19 +255,12 @@ def it_condition_have_proto_protocol_and_port_port_for_cidr(step_obj, condition,
         from_port, to_port = port.split('-')
     # In case we have comma delimited ports
     elif ',' in port:
-        print condition
-        assert condition == 'must only', "Comma delimited ports only for must only condition"
         from_port = to_port = '0'
         ports = port.split(',')
     else:
         from_port = to_port = port
 
-    if condition == 'must only':
-        condition = True
-    elif condition == 'must not':
-        condition = False
-    else:
-        raise AssertionError("Condition should be 'must only' or 'must not'")
+    condition = condition == 'only'
 
     for item in step_obj.context.stash.properties:
         if type(item.property_value) is list:

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -240,20 +240,33 @@ def its_value_must_be_set_by_a_variable(step_obj):
     step_obj.context.stash.property(step_obj.context.search_value).should_match_regex(r'\${var.(.*)}')
 
 
-@then(u'it must not have {proto:ANY} protocol and port {port:ANY} for {cidr:ANY}')
-def it_must_not_have_proto_protocol_and_port_port_for_cidr(step_obj, proto, port, cidr):
+@then(u'it {condition:ANY} have {proto:ANY} protocol and port {port} for {cidr:ANY}')
+def it_condition_have_proto_protocol_and_port_port_for_cidr(step_obj, condition, proto, port, cidr):
     proto = str(proto)
     cidr = str(cidr)
+    ports = port
+
+    if condition == 'must only':
+        condition = True
+    elif condition == 'must not':
+        condition = False
+    else:
+        raise AssertionError("Condition should be 'must only' or 'must not'")
 
     # In case we have a range
     if '-' in port:
         from_port, to_port = port.split('-')
+    # In case we have comma delimited ports
+    elif ',' in port:
+        assert condition == 'must only', "Comma delimited ports only for must only condition"
+        from_port = to_port = None
+        ports = port.split(',')
     else:
         from_port = to_port = port
 
     for item in step_obj.context.stash.properties:
         if type(item.property_value) is list:
             for security_group in item.property_value:
-                check_sg_rules(world.config.terraform.terraform_config, security_group, proto, from_port, to_port, cidr)
+                check_sg_rules(world.config.terraform.terraform_config, security_group, condition, proto, from_port, to_port, ports, cidr)
         else:
-            check_sg_rules(world.config.terraform.terraform_config, item.property_value, proto, from_port, to_port, cidr)
+            check_sg_rules(world.config.terraform.terraform_config, item.property_value, proto, condition, from_port, to_port, ports, cidr)

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -246,23 +246,24 @@ def it_condition_have_proto_protocol_and_port_port_for_cidr(step_obj, condition,
     cidr = str(cidr)
     ports = port
 
+    # In case we have a range
+    if '-' in port:
+        from_port, to_port = port.split('-')
+    # In case we have comma delimited ports
+    elif ',' in port:
+        print condition
+        assert condition == 'must only', "Comma delimited ports only for must only condition"
+        from_port = to_port = '0'
+        ports = port.split(',')
+    else:
+        from_port = to_port = port
+
     if condition == 'must only':
         condition = True
     elif condition == 'must not':
         condition = False
     else:
         raise AssertionError("Condition should be 'must only' or 'must not'")
-
-    # In case we have a range
-    if '-' in port:
-        from_port, to_port = port.split('-')
-    # In case we have comma delimited ports
-    elif ',' in port:
-        assert condition == 'must only', "Comma delimited ports only for must only condition"
-        from_port = to_port = None
-        ports = port.split(',')
-    else:
-        from_port = to_port = port
 
     for item in step_obj.context.stash.properties:
         if type(item.property_value) is list:

--- a/tests/terraform_compliance/common/test_helper.py
+++ b/tests/terraform_compliance/common/test_helper.py
@@ -129,7 +129,7 @@ class TestHelperFunctions(TestCase):
     def test_validate_sg_rule_port_not_found_in_comma_delimited_scenario(self):
         with self.assertRaises(AssertionError) as context:
             ports = '22,443'.split(',')
-            self.assertTrue(validate_sg_rule(True, 'tcp', '0', '0', ports, '0.0.0.0/0', MockedData.sg_params_list_range_public))
+            self.assertFalse(validate_sg_rule(True, 'tcp', '0', '0', ports, '0.0.0.0/0', MockedData.sg_params_list_range_public))
 
     def test_validate_sg_rule_port_found_in_comma_delimited_scenario(self):
         with self.assertRaises(AssertionError) as context:

--- a/tests/terraform_compliance/common/test_helper.py
+++ b/tests/terraform_compliance/common/test_helper.py
@@ -92,7 +92,7 @@ class TestHelperFunctions(TestCase):
 
     def test_validate_sg_rule_port_found_in_cidr(self):
         with self.assertRaises(AssertionError) as context:
-            validate_sg_rule('tcp', '22', '22', '0.0.0.0/0', MockedData.sg_params_all_port_all_ip)
+            validate_sg_rule(False, 'tcp', '22', '22', '', '0.0.0.0/0', MockedData.sg_params_all_port_all_ip)
             self.assertTrue('Found' in context.exception)
 
     def test_change_value_in_dict_with_str_path(self):
@@ -107,7 +107,7 @@ class TestHelperFunctions(TestCase):
 
     def test_validate_sg_rule_invalid_port_range_within_scenario(self):
         with self.assertRaises(AssertionError) as context:
-            validate_sg_rule('tcp', '43', '42', None, None)
+            validate_sg_rule(False, 'tcp', '43', '42', '', None, None)
 
             self.assertTrue('Port range is defined incorrectly within the Scenario.' in context.exception)
 
@@ -116,13 +116,23 @@ class TestHelperFunctions(TestCase):
         for scenario in scenario_list:
             with self.assertRaises(AssertionError) as context:
                 from_port, to_port = scenario.split('-')
-                validate_sg_rule('tcp', from_port, to_port, '0.0.0.0/0', MockedData.sg_params_list_range_public)
+                validate_sg_rule(False, 'tcp', from_port, to_port, '', '0.0.0.0/0', MockedData.sg_params_list_range_public)
                 self.assertTrue('Found' in context.exception)
 
     def test_validate_sg_rule_port_range_found_in_cidr_success_due_to_cidr_mismatch(self):
         scenario_list = ['22-80', '21-22', '21-23', '70-72', '79-80', '79-81']
         for scenario in scenario_list:
             from_port, to_port = scenario.split('-')
-            self.assertTrue(validate_sg_rule('tcp', from_port, to_port, '0.0.0.0/0',
+            self.assertTrue(validate_sg_rule(False, 'tcp', from_port, to_port, '', '0.0.0.0/0',
                                              MockedData.sg_params_list_range_private))
 
+    def test_validate_sg_rule_port_not_found_in_comma_delimited_scenario(self):
+        with self.assertRaises(AssertionError) as context:
+            ports = '22,443'.split(',')
+            self.assertTrue(validate_sg_rule(True, 'tcp', '0', '0', ports, '0.0.0.0/0', MockedData.sg_params_list_range_public))
+
+    def test_validate_sg_rule_port_found_in_comma_delimited_scenario(self):
+        with self.assertRaises(AssertionError) as context:
+            ports = range(22,80)
+            ports = [str(i) for i in ports]
+            self.assertFalse(validate_sg_rule(True, 'tcp', '0', '0', ports, '0.0.0.0/0', MockedData.sg_params_list_range_public))

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -6,7 +6,7 @@ from terraform_compliance.steps.steps import (
     encryption_is_enabled,
     its_value_condition_match_the_search_regex_regex,
     its_value_must_be_set_by_a_variable,
-    it_must_not_have_proto_protocol_and_port_port_for_cidr
+    it_condition_have_proto_protocol_and_port_port_for_cidr
 )
 from tests.mocks import MockedStep, MockedWorld, MockedTerraformPropertyList, MockedTerraformResourceList
 from mock import patch


### PR DESCRIPTION
Currently Security Group Rule validation can do "must not have" for individual ports and port ranges.

This pull request will implement "must only have" condition for security group rule with ports defined as comma delimited values.