### PR TITLE
Upgraded radish-bdd, added a new untaggable resource.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 terraform_validate==2.8.0
 radish==0.1.10
-radish-bdd==0.10.0
+radish-bdd==0.11.1
 gitpython==2.1.10
 mock==2.0.0
 netaddr==0.7.19

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 
 

--- a/terraform_compliance/steps/__init__.py
+++ b/terraform_compliance/steps/__init__.py
@@ -27,7 +27,8 @@ untaggable_resources = [
     "aws_kms_alias",
     "aws_kinesis_firehose_delivery_stream",
     "aws_vpc_dhcp_options_association",
-    "null_resource"
+    "null_resource",
+    "random_string"
 ]
 
 encryption_property = {


### PR DESCRIPTION
* Upgraded `radish-bdd` from 0.10.0 to 0.11.1
* Added `random_string` as a untaggable resource. (#67)
* Addresses the problem identified in #79.