### PR TITLE
Upgrade to use python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '3.2'
   - '3.3'
   - '3.4'
   - '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success: coveralls
 script: nosetests
 jobs:
   include:
-    - python: '3.2'
+    - python: '3.3'
     - python: '3.4'
     - python: '3.5'
     - python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: python
-python:
-  - '3.3'
-  - '3.4'
-  - '3.5'
-  - '3.6'
-  - '3.7-dev'
 services:
   - docker
 cache:
@@ -13,8 +7,14 @@ install:
   - pip install coveralls
   - pip install -r requirements.txt
 after_success: coveralls
+script: nosetests
 jobs:
   include:
+    - python: '3.2'
+    - python: '3.4'
+    - python: '3.5'
+    - python: '3.6'
+    - python: '3.7-dev'
     - stage: Tests
       provider: script
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - '3.7-dev'
+  - '3.6'
 services:
   - docker
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 python:
-  - '3.0'
-  - '3.1'
   - '3.2'
   - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'
-  - '3.7'
+  - '3.7-dev'
 services:
   - docker
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - '3.7-dev'
 services:
   - docker
 cache:
@@ -7,14 +9,8 @@ install:
   - pip install coveralls
   - pip install -r requirements.txt
 after_success: coveralls
-script: nosetests
 jobs:
   include:
-    - python: '3.3'
-    - python: '3.4'
-    - python: '3.5'
-    - python: '3.6'
-    - python: '3.7-dev'
     - stage: Tests
       provider: script
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
-  - '2.7'
+  - '3.0'
+  - '3.1'
+  - '3.2'
+  - '3.3'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+  - '3.7'
 services:
   - docker
 cache:

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM python:2.7.15-slim
+FROM python:3.6.8-slim
 
 LABEL terraform_compliance.version="__VERSION__"
 LABEL author="Emre Erkunt <emre.erkunt@gmail.com>"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,14 @@ setup(
         'Operating System :: Unix',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.0',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -155,7 +155,7 @@ def change_value_in_dict(target_dictionary, path_to_change, value_to_change):
     if type(path_to_change) is not list:
         return False
 
-    for x in xrange(0,len(path_to_change)):
+    for x in range(0,len(path_to_change)):
         for condition in hcl_conditions:
             if condition in path_to_change[x]:
                 return False

--- a/terraform_compliance/extensions/ext_radish_bdd.py
+++ b/terraform_compliance/extensions/ext_radish_bdd.py
@@ -50,4 +50,4 @@ def write_stdout(level, message):
     added_prefix = u'\n\t\t{}\t{} '.format(colorful.gray(u'\u2502'),' '*len(prefix))
     message = message.split('\n')
 
-    console_write(u'\t\t\u251c\u2501\t{} {}'.format(prefix, added_prefix.join(message)).encode('utf-8'))
+    print(u'\t\t\u251c\u2501\t{} {}'.format(prefix, added_prefix.join(message)).encode('utf-8'))

--- a/terraform_compliance/extensions/terraform_validate.py
+++ b/terraform_compliance/extensions/terraform_validate.py
@@ -23,7 +23,7 @@ def enable_resource_mounting(tf_conf, processing_resource=None, resource=None):
     source = resource.strip()
     source = (source[:-3] if source.endswith('.id') else source)
 
-    for sub_resource, sub_value in processing_resource.items():
+    for sub_resource, sub_value in list(processing_resource.items()):
 
         if type(sub_value) is dict:
             enable_resource_mounting(tf_conf, sub_value, sub_resource)

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 
 

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -2,12 +2,6 @@ import os
 from argparse import ArgumentParser
 from sys import exc_info, exit, executable
 
-# Temporary Python 2 unicode compatibility
-import sys
-
-reload(sys)
-sys.setdefaultencoding('utf8')
-
 try:
     from radish.main import main as call_radish
 except ImportError as e:
@@ -15,7 +9,7 @@ except ImportError as e:
 
 
     def pip(action, package, params=None):
-        print '{}ing {}..'.format(action, package)
+        print('{}ing {}..'.format(action, package))
 
         if action == 'uninstall':
             cmds = [executable, "-m", "pip", action, '--yes', package]
@@ -24,15 +18,15 @@ except ImportError as e:
 
         subprocess.call(cmds)
 
-    print "Fixing the problem on radish and radish-bdd"
+    print("Fixing the problem on radish and radish-bdd")
     pip('uninstall', 'radish-bdd')
     pip('uninstall', 'radish')
     pip('install', 'radish==0.1.10')
     pip('install', 'radish-bdd==0.8.6')
 
-    print "~"*40
-    print " Please run terraform-compliance again."
-    print "~"*40
+    print("~"*40)
+    print(" Please run terraform-compliance again.")
+    print("~"*40)
     exit(1)
 
 from tempfile import mkdtemp
@@ -111,7 +105,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
     try:
         load_tf_files(tf_directory)
     except TerraformComplianceInvalidConfig:
-        print exc_info()[1]
+        print(exc_info()[1])
         exit(1)
 
     print('Running tests.')

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -39,7 +39,7 @@ from terraform_compliance.common.exceptions import TerraformComplianceInvalidCon
 
 
 __app_name__ = "terraform-compliance"
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 
 

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -196,7 +196,7 @@ def encryption_is_enabled(step_obj):
 def its_value_condition_match_the_search_regex_regex(step_obj, condition, search_regex):
     regex = r'{}'.format(search_regex)
 
-    if step_obj.context.stash.__class__ in (str, unicode):
+    if step_obj.context.stash.__class__ is str:
         matches = re.match(regex, step_obj.context.stash)
 
         if condition == 'must':
@@ -215,7 +215,7 @@ def its_value_condition_match_the_search_regex_regex(step_obj, condition, search
         normalise_tag_values(step_obj.context.stash)
 
         for prop in step_obj.context.stash.properties:
-            if type(prop.property_value) in [str, unicode]:
+            if type(prop.property_value) is str:
                 prop.property_value = [prop.property_value]
             elif type(prop.property_value) is dict:
                 prop.property_value = prop.property_value.values()

--- a/tests/terraform_compliance/common/test_pyhcl_helper.py
+++ b/tests/terraform_compliance/common/test_pyhcl_helper.py
@@ -7,7 +7,7 @@ from terraform_compliance.common.pyhcl_helper import (
 )
 from tests.mocks import MockedValidator
 from os import remove, path, environ
-from mock import patch
+from unittest.mock import patch
 
 
 class TestPyHCLHelper(TestCase):
@@ -15,9 +15,10 @@ class TestPyHCLHelper(TestCase):
     def test_pad_tf_file(self):
         tmpFile = '.terraform_compliance_unit_tests.tf'
         pad_tf_file(tmpFile)
-        contents = open(tmpFile, 'r').read()
-        remove(tmpFile)
-        self.assertEqual(contents, '\n\nvariable {}')
+        with open(tmpFile, 'r') as file:
+            contents = file.read()
+            remove(tmpFile)
+            self.assertEqual(contents, '\n\nvariable {}')
 
     @patch('terraform_compliance.common.pyhcl_helper.pad_tf_file', return_value=None)
     def test_pad_invalid_tf_files(self, *args):

--- a/tests/terraform_compliance/extensions/test_ext_radish_bdd.py
+++ b/tests/terraform_compliance/extensions/test_ext_radish_bdd.py
@@ -3,9 +3,6 @@ from terraform_compliance.extensions.ext_radish_bdd import skip_step, write_stdo
 from tests.mocks import MockedStep
 import sys
 
-reload(sys)
-sys.setdefaultencoding('utf8')
-
 class TestRadishBddExtension(TestCase):
     def test_step_condition(self):
         step = MockedStep()

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -9,7 +9,7 @@ from terraform_compliance.steps.steps import (
     it_condition_have_proto_protocol_and_port_port_for_cidr
 )
 from tests.mocks import MockedStep, MockedWorld, MockedTerraformPropertyList, MockedTerraformResourceList
-from mock import patch
+from unittest.mock import patch
 
 
 class Test_Step_Cases(TestCase):

--- a/tests/terraform_compliance/test_main.py
+++ b/tests/terraform_compliance/test_main.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from terraform_compliance.main import ReadableDir, cli
 from tests.mocks import MockedArgumentParser, MockedArgHandling
-from mock import patch
+from unittest.mock import patch
 import os
 
 


### PR DESCRIPTION
Hi, I am looking to use this tool for a shared modules repository I am working on for our company.  I noticed that you are still using python 2.7 and decided to take a crack at upgrading to python 3.x.  All tests pass on my machine, and there weren't many things that needed to get changed.