### PR TITLE
Include Terraform in the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 1.0.12 (2019-06-28)
+* Include the Terraform binary in the Docker container for use on non-Linux host operating systems [#102](https://github.com/eerkunt/terraform-compliance/issues/102)
+
 ### 1.0.11 (2019-06-28)
 * Added a new step: _its value must/must not be null_ [#106](https://github.com/eerkunt/terraform-compliance/blob/master/example/example_01/aws/restrict_resource_creation.feature) [#105](https://github.com/eerkunt/terraform-compliance/issues/106)
 * Added support for `data` definitions. [#111](https://github.com/eerkunt/terraform-compliance/blob/master/example/example_01/aws/restrict_resource_creation.feature) [#105](https://github.com/eerkunt/terraform-compliance/issues/111)

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,9 +7,9 @@ LABEL source="https://github.com/eerkunt/terraform-compliance"
 ENV TERRAFORM_VERSION=0.12.3
 
 RUN  apt-get update && \
-     apt-get install -y git && \
-     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
+     apt-get install -y git curl unzip && \
+     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip --output terraform_linux_amd64.zip && \
+     unzip terraform_linux_amd64.zip -d /usr/bin && \
      pip install 'terraform-compliance==__VERSION__' && \
      pip uninstall -y radish radish-bdd && \
      pip install radish radish-bdd && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,8 +4,12 @@ LABEL terraform_compliance.version="__VERSION__"
 LABEL author="Emre Erkunt <emre.erkunt@gmail.com>"
 LABEL source="https://github.com/eerkunt/terraform-compliance"
 
+ENV TERRAFORM_VERSION=0.12.3
+
 RUN  apt-get update && \
      apt-get install -y git && \
+     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
      pip install 'terraform-compliance==__VERSION__' && \
      pip uninstall -y radish radish-bdd && \
      pip install radish radish-bdd && \

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -11,7 +11,7 @@ except ImportError as e:
     reinstall_radish()
 
 __app_name__ = "terraform-compliance"
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 
 print('{} v{} initiated\n'.format(__app_name__, __version__))
 


### PR DESCRIPTION
Relates to
https://github.com/eerkunt/terraform-compliance/issues/102

When developing on a non-Linux system (such as Mac OS), the terraform binary cannot be mounted into the container from the host as it is not compiled for the same OS.

I understand this might not be the best way to handle this...