### PR TITLE
regex =='\x00' if condition fails when the input regex is euqal to \x00

### DIFF
--- a/example/example_01/aws/encryption_at_rest.feature
+++ b/example/example_01/aws/encryption_at_rest.feature
@@ -9,7 +9,7 @@ Feature: Resources should use encryption at rest while they are created
 
   Scenario: EBS volumes
     Given I have AWS EBS volume defined
-    Then encryption_at_rest_property must be enabled
+    Then encryption at rest must be enabled
 
   Scenario: S3 Buckets
     Given I have AWS S3 Bucket defined

--- a/example/example_01/aws/encryption_in_flight.feature
+++ b/example/example_01/aws/encryption_in_flight.feature
@@ -10,8 +10,8 @@ Feature: Resources that exposes to external networks should have encryption in f
   
   Scenario: AWS EMR Sceurity Configuration Encryption in Flight must be enabled
     Given I have AWS EMR Security Configuration defined
-    Then encryption_in_flight must be enabled
+    Then encryption in flight must be enabled
 
   Scenario: AWS ElastiCache Replication Group Encryption in Flight must be enabled
     Given I have AWS ElastiCache Replication Group defined
-    Then encryption_in_flight must be enabled
+    Then encryption in flight must be enabled

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -7,7 +7,7 @@ from terraform_compliance.common.readable_plan import ReadablePlan
 from radish.main import main as call_radish
 
 __app_name__ = "terraform-compliance"
-__version__ = "1.0.25"
+__version__ = "1.0.26"
 
 
 print('{} v{} initiated\n'.format(__app_name__, __version__))

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -364,7 +364,7 @@ def its_value_condition_match_the_search_regex_regex(_step_obj, condition, searc
 
     elif type(values) is dict:
         if 'values' in values:
-            if values['values'] is None and regex == 'null' and condition == 'must not':
+            if values['values'] is None and regex == '\x00' and condition == 'must not':
                 values = values['values']
                 fail(condition, name=_stash.get('address'))
             else:

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -374,7 +374,7 @@ def its_value_condition_match_the_search_regex_regex(_step_obj, condition, searc
 
     elif type(values) is dict:
         if 'values' in values:
-            if values['values'] is None and regex == '\x00' and condition == 'must not':
+            if values['values'] is None and regex == 'null' and condition == 'must not':
                 values = values['values']
                 fail(condition, name=_stash.get('address'))
             else:


### PR DESCRIPTION
Step `And its value must not match the "\x00" regex` is passed even though the property value in plan is null.
so, I changed the code in steps.py and replaced line#377
` if values['values'] is None and regex == '\x00' and condition == 'must not':`

with

` if values['values'] is None and regex == 'null' and condition == 'must not':`

and the rule worked as expected.