### PR TITLE
Support parsing resource changes in plan

### DIFF
--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -111,14 +111,17 @@ class TerraformParser(object):
         # Resource Changes ( exists in Plan )
         for finding in self.raw.get('resource_changes', {}):
             resource = deepcopy(finding)
-            resource['values'] = resource.get('change', {}).get('after', {})
-            if 'change' in resource:
-                del resource['change']
+            change = resource.get('change', {})
+            actions = change.get('actions', [])
+            if actions != ['delete']:
+                resource['values'] = change.get('after', {})
+                if 'change' in resource:
+                    del resource['change']
 
-            if resource['address'].startswith('data'):
-                self.data[resource['address']] = resource
-            else:
-                self.resources[resource['address']] = resource
+                if resource['address'].startswith('data'):
+                    self.data[resource['address']] = resource
+                else:
+                    self.resources[resource['address']] = resource
 
     def _parse_configurations(self):
         '''

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -76,8 +76,6 @@ class TerraformParser(object):
         :return: none
         '''
 
-        #TODO: Consider about using 'resource_changes' instead of 'resources'
-
         # Resources ( exists in Plan )
         for findings in seek_key_in_dict(self.raw.get('planned_values', {}).get('root_module', {}), 'resources'):
             for resource in findings.get('resources', []):
@@ -109,6 +107,18 @@ class TerraformParser(object):
                     self.data[resource['address']] = resource
                 else:
                     self.resources[resource['address']] = resource
+
+        # Resource Changes ( exists in Plan )
+        for finding in self.raw.get('resource_changes', {}):
+            resource = deepcopy(finding)
+            resource['values'] = resource.get('change', {}).get('after', {})
+            if 'change' in resource:
+                del resource['change']
+
+            if resource['address'].startswith('data'):
+                self.data[resource['address']] = resource
+            else:
+                self.resources[resource['address']] = resource
 
     def _parse_configurations(self):
         '''

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -195,6 +195,26 @@ class TestTerraformParser(TestCase):
         self.assertEqual(obj.resources['something'], {'address': 'something', 'values': {'key': 'bar'}})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_resources_resources_exists_in_the_resource_changes_deleted(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['resource_changes'] = [
+            {
+                'address': 'something',
+                'change': {
+                    'actions': ['delete'],
+                    'before': {
+                        'key': 'foo'
+                    },
+                    'after': {
+                        'key': 'bar'
+                    }
+                }
+            }
+        ]
+        obj._parse_resources()
+        self.assertEqual(obj.resources, {})
+
+    @patch.object(TerraformParser, '_read_file', return_value={})
     def test_parse_configurations_resources(self, *args):
         obj = TerraformParser('somefile', parse_it=False)
         obj.raw['configuration'] = {

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -154,6 +154,45 @@ class TestTerraformParser(TestCase):
         obj._parse_resources()
         self.assertEqual(obj.resources['something'], {'address': 'something'})
 
+    @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_resources_resources_exists_in_the_resource_changes_data(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['resource_changes'] = [
+            {
+                'address': 'data_something',
+                'change': {
+                    'actions': ['update'],
+                    'before': {
+                        'key': 'foo'
+                    },
+                    'after': {
+                        'key': 'bar'
+                    }
+                }
+            }
+        ]
+        obj._parse_resources()
+        self.assertEqual(obj.data['data_something'], {'address': 'data_something', 'values': {'key': 'bar'}})
+
+    @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_resources_resources_exists_in_the_resource_changes_resource(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['resource_changes'] = [
+            {
+                'address': 'something',
+                'change': {
+                    'actions': ['update'],
+                    'before': {
+                        'key': 'foo'
+                    },
+                    'after': {
+                        'key': 'bar'
+                    }
+                }
+            }
+        ]
+        obj._parse_resources()
+        self.assertEqual(obj.resources['something'], {'address': 'something', 'values': {'key': 'bar'}})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
     def test_parse_configurations_resources(self, *args):


### PR DESCRIPTION
I've run into a couple of situations where non-compliant resources are not caught because they don't show up in the `planned_changes` block of the output file. Parsing the `resource_changes` block in the terraform plan output seems to fix the issue. Seems like this was something that was planned anyway from the TODO.