### PR TITLE
Resource mounting problems on resource that supports tags

### DIFF
--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -4,6 +4,7 @@ from terraform_compliance.steps import resource_name
 from terraform_compliance.common.exceptions import Failure
 from collections.abc import Iterable
 import json
+from copy import deepcopy
 
 
 class EmptyStash(object):
@@ -298,3 +299,16 @@ def get_resource_address_list_from_stash(resource_list):
                 address_list.append(resource['address'])
 
     return address_list
+
+def remove_mounted_resources(resource_list):
+    if type(resource_list) is not list:
+        return resource_list
+
+    resources = deepcopy(resource_list)
+    for resource in resources:
+        if 'terraform-compliance.mounted_resources' in resource:
+            for mounted_resource_type in resource['terraform-compliance.mounted_resources']:
+                if mounted_resource_type in resource['values']:
+                    del resource['values'][mounted_resource_type]
+
+    return resources

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -5,6 +5,7 @@ from terraform_compliance.steps import property_match_list
 from terraform_compliance.common.helper import check_sg_rules, convert_resource_type, find_root_by_key, seek_key_in_dict
 from terraform_compliance.common.helper import seek_regex_key_in_dict_values, jsonify, Null, EmptyStash
 from terraform_compliance.common.helper import get_resource_name_from_stash, get_resource_address_list_from_stash
+from terraform_compliance.common.helper import remove_mounted_resources
 from terraform_compliance.extensions.ext_radish_bdd import skip_step
 from terraform_compliance.extensions.ext_radish_bdd import custom_type_any
 from terraform_compliance.extensions.ext_radish_bdd import custom_type_condition
@@ -53,7 +54,11 @@ def i_have_name_section_configured(_step_obj, name, type_name='resource', _terra
                                                         return_key='type')
         resource_list = []
         for resource_type in resource_types_supports_tags:
-            resource_list.extend(_terraform_config.config.terraform.find_resources_by_type(resource_type))
+            # Issue-168: Mounted resources causes problem on recursive searching for resources that supports tags
+            #            We are removing all mounted resources here for future steps, since we don't need them for
+            #            tags checking.
+            found_resources = remove_mounted_resources(_terraform_config.config.terraform.find_resources_by_type(resource_type))
+            resource_list.extend(found_resources)
 
         if resource_list:
             _step_obj.context.type = type_name
@@ -382,7 +387,6 @@ def i_action_them(_step_obj, action_type):
     else:
         raise TerraformComplianceNotImplemented('Invalid action_type in the scenario: {}'.format(action_type))
 
-
 @then(u'its value must be {operator:ANY} than {number:d}')
 @then(u'I expect the result is {operator:ANY} than {number:d}')
 @then(u'its value must be {operator:ANY} to {number:d}')
@@ -426,7 +430,6 @@ def i_expect_the_result_is_operator_than_number(_step_obj, operator, number, _st
     elif type(values) is Null:
         raise TerraformComplianceNotImplemented('Null/Empty value found on {}'.format(_step_obj.context.type))
 
-
 @step(u'its value {condition:ANY} match the "{search_regex}" regex')
 def its_value_condition_match_the_search_regex_regex(_step_obj, condition, search_regex, _stash=EmptyStash):
     def fail(condition, name=None):
@@ -466,11 +469,9 @@ def its_value_condition_match_the_search_regex_regex(_step_obj, condition, searc
             for key, value in values.items():
                 its_value_condition_match_the_search_regex_regex(_step_obj, condition, search_regex, value)
 
-
 @step(u'its value {condition:ANY} be {match:ANY}')
 def its_value_condition_equal(_step_obj, condition, match, _stash=EmptyStash):
     its_value_condition_match_the_search_regex_regex(_step_obj, condition, "^" + re.escape(match) + "$", _stash)
-
 
 @then(u'its value {condition:ANY} contain {value:ANY}')
 def its_value_condition_contain(_step_obj, condition, value, _stash=EmptyStash):
@@ -482,7 +483,6 @@ def its_value_condition_contain(_step_obj, condition, value, _stash=EmptyStash):
         _its_value_condition_contain(_step_obj, condition, value, values.get('values', Null))
     elif type(values) is Null:
         raise TerraformComplianceNotImplemented('Null/Empty value found on {}'.format(_step_obj.context.type))
-
 
 def _its_value_condition_contain(_step_obj, condition, value, values):
     assert condition in ('must', 'must not'), 'Condition should be one of: `must`, `must not`'
@@ -506,7 +506,6 @@ def _its_value_condition_contain(_step_obj, condition, value, values):
     else:
         raise Failure('Can only check that if list contains value')
 
-
 @then(u'the scenario fails')
 @then(u'the scenario should fail')
 @then(u'the scenario must fail')
@@ -517,7 +516,6 @@ def it_fails(_step_obj):
     raise Failure('Forcefully failing the scenario on {} ({}) {}'.format(_step_obj.context.name,
                                                                          ', '.join(_step_obj.context.addresses),
                                                                          _step_obj.context.type))
-
 
 @then(u'its value {condition:ANY} be null')
 def its_value_condition_be_null(_step_obj, condition):

--- a/tests/terraform_compliance/common/test_helper.py
+++ b/tests/terraform_compliance/common/test_helper.py
@@ -10,7 +10,8 @@ from terraform_compliance.common.helper import (
     are_networks_same,
     convert_resource_type,
     seek_regex_key_in_dict_values,
-    jsonify
+    jsonify,
+    remove_mounted_resources
 )
 from terraform_compliance.common.exceptions import Failure
 from tests.mocks import MockedData
@@ -208,3 +209,32 @@ class TestHelperFunctions(TestCase):
         self.assertEqual(jsonify(12), 12)
         self.assertEqual(jsonify('something'), 'something')
         self.assertEqual(jsonify('{"test": "test_value"}'), {'test': 'test_value'})
+
+    def test_remove_mounted_resources(self, *args):
+        resource_list = {
+            'address': 'aws_subnet.test',
+            'type': 'aws_subnet',
+            'name': 'test',
+            'values': {
+                'tags': None,
+                'aws_vpc': [
+                    {
+                        'tags': {
+                            'Environment': 'Sandbox',
+                            'Name': 'mcrilly-sandbox'
+                        },
+                        'aws_subnet': [
+                            {
+                                'tags': None,
+                                'terraform-compliance.mounted': True
+                            }
+                        ], 'terraform-compliance.mounted': True
+                    }
+                ]
+            },
+            'terraform-compliance.mounted_resources': [
+                'aws_vpc'
+            ]
+        }
+        output = remove_mounted_resources([resource_list])
+        self.assertEqual({'tags': None}, output[0]['values'])

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -277,8 +277,7 @@ class TestTerraformParser(TestCase):
             }
         }
         obj._mount_resources([source], [target], ref_type)
-        self.assertEqual(['a', {'some_key': 'some_value'}], obj.resources[target]['values'][ref_type])
-
+        self.assertEqual(['a', {'some_key': 'some_value', 'terraform-compliance.mounted': True}], obj.resources[target]['values'][ref_type])
 
     @patch.object(TerraformParser, '_read_file', return_value={})
     def test_mount_resources_without_ref_type(self, *args):
@@ -297,7 +296,7 @@ class TestTerraformParser(TestCase):
             }
         }
         obj._mount_resources([source], [target], ref_type)
-        self.assertEqual([{'some_key': 'some_value'}], obj.resources[target]['values'][ref_type])
+        self.assertEqual([{'some_key': 'some_value', 'terraform-compliance.mounted': True}], obj.resources[target]['values'][ref_type])
 
     @patch.object(TerraformParser, '_read_file', return_value={})
     def test_mount_resources_failure_if_source_resource_does_not_have_values(self, *args):
@@ -419,3 +418,4 @@ class TestTerraformParser(TestCase):
 
         self.assertEqual(obj.find_resources_by_type('invalid_resource'),
                          [])
+


### PR DESCRIPTION
As also reported in #168, a problem exists where resource mounting and recursive searching were causing a problem on `resources that support tags` where we should not either do recursive searching or resource mounting.

This PR will disable resource mounting on scenarios where `resources that support tags` are used.