### PR TITLE
Support for provider aliases and multiple provider definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.53 (2019-10-30)
 * Fixed a problem where resource names were reported wrong in some failures. ([#171](https://github.com/eerkunt/terraform-compliance/issues/171))
 * Fixed a problem where in some cases `teraform-compliance` where giving `AttributeError: 'NoneType' object has no attribute 'get'` exception. ([#172](https://github.com/eerkunt/terraform-compliance/issues/172))
+* Supporting multiple provider or providers aliases. ([#173](https://github.com/eerkunt/terraform-compliance/issues/173))
 
 ## 1.0.52 (2019-10-29)
 * Fixed a problem where resource mounting were causing a issues on `resources that support tags`. ([#168](https://github.com/eerkunt/terraform-compliance/issues/168))

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -300,7 +300,7 @@ def get_resource_address_list_from_stash(resource_list):
     address_list = []
     for resource in resource_list:
         if 'address' in resource and resource['address'] not in address_list:
-                address_list.append(resource['address'])
+            address_list.append(resource['address'])
 
     return address_list
 

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -311,3 +311,17 @@ class TerraformParser(object):
                 resource_list.append(resource_data)
 
         return resource_list
+
+    def get_providers_from_configuration(self, provider_type):
+        '''
+        Returns all providers as a list for the given provider type
+
+        :param provider_type: String of a provider type like aws
+        :return: list of providers that has this type
+        '''
+        providers = []
+        for provider_alias, values in self.configuration['providers'].items():
+            if type(values) is dict and values.get('name') == provider_type:
+                providers.append(values)
+
+        return providers

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -294,7 +294,10 @@ def it_condition_contain_something(_step_obj, something):
                 raise Failure('{} {} does not have {} property.'.format(_step_obj.context.addresses,
                                                                         _step_obj.context.type,
                                                                         something))
-
+        if 'must' in _step_obj.context_sensitive_sentence:
+            raise Failure('{} {} does not have {} property.'.format(_step_obj.context.addresses,
+                                                                    _step_obj.context.type,
+                                                                    something))
     skip_step(_step_obj,
               resource=_step_obj.context.name,
               message='Skipping the step since {} type does not have {} property.'.format(_step_obj.context.type,

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -139,7 +139,7 @@ def its_key_is_value(_step_obj, key, value):
             if "[" in object_key:
                 object_key = object_key.split('[')[0]
 
-            if object_key == value:
+            if object_key.lower() == value.lower():
                 found_list.append(obj)
 
         elif type(object_key) in (int, bool) and object_key == value:
@@ -417,8 +417,12 @@ def i_expect_the_result_is_operator_than_number(_step_obj, operator, number, _st
             i_expect_the_result_is_operator_than_number(_step_obj, operator, number, _stash=value_set)
 
     elif type(values) is dict:
-        _step_obj.context.property_name = values.get('type')
-        _step_obj.context.address = values.get('address')
+        _step_obj.context.property_name = values.get('type', _step_obj.context.property_name)
+        _step_obj.context.address = values.get('address', _step_obj.context.addresses)
+
+        if type(_step_obj.context.address) is list and len(_step_obj.context.address) == 1:
+            _step_obj.context.address = _step_obj.context.address[0]
+
         i_expect_the_result_is_operator_than_number(_step_obj, operator, number, values.get('values', Null))
 
     elif type(values) is int or type(values) is str:
@@ -439,7 +443,7 @@ def i_expect_the_result_is_operator_than_number(_step_obj, operator, number, _st
     elif type(values) is Null:
         raise TerraformComplianceNotImplemented('Null/Empty value found on {}'.format(_step_obj.context.type))
 
-@step(u'its value {condition:ANY} match the "{search_regex}" regex')
+@then(u'its value {condition:ANY} match the "{search_regex}" regex')
 def its_value_condition_match_the_search_regex_regex(_step_obj, condition, search_regex, _stash=EmptyStash):
     def fail(condition, name=None):
         text = 'matches' if condition == 'must not' else 'does not match'

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -314,6 +314,9 @@ class MockedWorldConfigTerraform(object):
             if value['type'] == resource_type:
                 return [value]
 
+    def get_providers_from_configuration(self, provider_type):
+        return []
+
 
 class MockedTerraformPropertyList(object):
     def __init__(self):

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -189,7 +189,7 @@ class Test_Step_Cases(TestCase):
     def test_it_condition_contain_something_provider_found(self, *args):
         step = MockedStep()
         step.context.type = 'provider'
-        step.context.stash = []
+        step.context.stash = [{'name': 'test'}]
 
         self.assertTrue(it_condition_contain_something(step, 'something'))
 


### PR DESCRIPTION
`terraform-compliance` was failing to test properly while having multiple provider definitions or provider aliases, also reported in #173

This problem adds this capability while fixing the issue.