### PR TITLE
Add reference for type an minor corrections

### DIFF
--- a/docs/pages/bdd-references/when.md
+++ b/docs/pages/bdd-references/when.md
@@ -35,7 +35,7 @@ directives could be enough for you.
 
 You can use `AND` with `WHEN`.
 
-Depending on use a [Scenario Outline](/pages/bdd-references#Scenario) instead of a Scenario, it can also 
+Depending on use a [Scenario Outline](/pages/bdd-references#Scenario) instead of a Scenario, it can also
 be a variable like ;
 
 ```gherkin
@@ -43,7 +43,7 @@ When it contains <some_property>
 ```
 
 In case a `WHEN` step fails to complete, then the step and further steps will be `SKIPPED`. Skipped steps won't fail
-`terraform-compliance`. It means the definition criterias (not the testing criterias) defined in your Scenario does 
+`terraform-compliance`. It means the definition criteria (not the testing criteria) defined in your Scenario does
 not met with the infrastructure plan.
 
 ## Reference
@@ -56,30 +56,30 @@ not met with the infrastructure plan.
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 it contain
-[something](#){: .p-1 .text-green-200 .fw-700} 
+[something](#){: .p-1 .text-green-200 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 it contains
-[something](#){: .p-1 .text-green-200 .fw-700} 
+[something](#){: .p-1 .text-green-200 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 it has
-[something](#){: .p-1 .text-green-200 .fw-700} 
+[something](#){: .p-1 .text-green-200 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 they have
-[something](#){: .p-1 .text-green-200 .fw-700} 
+[something](#){: .p-1 .text-green-200 .fw-700}
 >
 | key | Description | Examples |
 |:---:|:----------|:-|
-| [something](#){: .p-1 .text-green-200 .fw-700} | any property within terraform resoruce/provider/etc | `access_key` `ingress` |
- 
- 
+| [something](#){: .p-1 .text-green-200 .fw-700} | any property within Terraform resoruce/provider/etc | `access_key` `ingress` |
+
+
 ------------------------
 ### [When](#){: .p-1 .text-red-200} its [property](#){: .p-1 .text-green-200 .fw-700} has [something](#){: .p-1 .text-blue-100 .fw-700}
 This is a filtering function. Thus, found resources from previous step will be filtered based on these values.
@@ -87,86 +87,86 @@ This is a filtering function. Thus, found resources from previous step will be f
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 is
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 has
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 includes
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 consists
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 is
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 has
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 includes
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 consists
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[dictionary](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[dictionary](#){: .p-1 .text-green-200 .fw-700}
 includes an entry where
 "
-[key](#){: .p-1 .text-blue-100 .fw-700} 
+[key](#){: .p-1 .text-blue-100 .fw-700}
 "
 is
 "
-[value](#){: .p-1 .text-blue-100 .fw-700} 
+[value](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 >
 | key | Description | Examples |
 |:---:|:----------|:-|
-| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resource have (e.g. `name`, `address`, etc. ). Using `address` will give the terraform object name | `address` `name` `size` |
+| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resources have. Using `type` will give the Terraform resource type; `address` is the name you have given it | `address` `name` `size` |
 | [dictionary](#){: .p-1 .text-green-200 .fw-700} | a dictionary property that resource has. | `tags` |
 | [something](#){: .p-1 .text-blue-100 .fw-700} | any string or numeric value that the property has. | `s3_my_bucket` `my-bucket` `50G` |
 | [some string with spaces](#){: .p-1 .text-blue-100 .fw-700} | any string (allows spaces). | `my dictionary key` |
@@ -181,67 +181,67 @@ the `property` property defined within the step.
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference is
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference has
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference includes
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference consists
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference is
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference has
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference includes
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference consists
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 >
@@ -258,86 +258,86 @@ This is a filtering function. Thus, found resources from previous step will be f
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 is not
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
-has not 
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+has not
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 does not include
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 does not consist
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 is not
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
-has not 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+has not
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 does not include
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 does not consist
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[dictionary](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[dictionary](#){: .p-1 .text-green-200 .fw-700}
 does not include an entry where
 "
-[key](#){: .p-1 .text-blue-100 .fw-700} 
+[key](#){: .p-1 .text-blue-100 .fw-700}
 "
 is
 "
-[value](#){: .p-1 .text-blue-100 .fw-700} 
+[value](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 >
 | key | Description | Examples |
 |:---:|:----------|:-|
-| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resource have (e.g. `name`, `address`, etc. ). Using `address` will give the terraform object name | `address` `name` `size`|
+| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resources have. Using `type` will give the Terraform resource type; `address` is the name you have given it | `address` `name` `size`|
 | [dictionary](#){: .p-1 .text-green-200 .fw-700} | a dictionary property that resource has. | `tags` |
 | [something](#){: .p-1 .text-blue-100 .fw-700} | any string or numeric value that the property has. | `s3_my_bucket` `my-bucket` `50G` |
 | [some string with spaces](#){: .p-1 .text-blue-100 .fw-700} | any string (allows spaces). | `my dictionary key` |
@@ -353,67 +353,67 @@ filtering step.
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference is not
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference has not
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference does not include
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference does not consist
-[something](#){: .p-1 .text-blue-100 .fw-700} 
+[something](#){: .p-1 .text-blue-100 .fw-700}
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference is not
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference has not
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference does not include
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
-its 
-[property](#){: .p-1 .text-green-200 .fw-700} 
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
 reference does not consist
 "
-[some string with spaces](#){: .p-1 .text-blue-100 .fw-700} 
+[some string with spaces](#){: .p-1 .text-blue-100 .fw-700}
 "
 >
 >
@@ -431,21 +431,21 @@ This step is for mathematical operations. Currently it is only supported for `co
 > __Possible sentences :__
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 I
-[action](#){: .p-1 .text-green-200 .fw-700} 
+[action](#){: .p-1 .text-green-200 .fw-700}
 them
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 I
-[action](#){: .p-1 .text-green-200 .fw-700} 
+[action](#){: .p-1 .text-green-200 .fw-700}
 it
 >
 > ▪
-[When](#){: .p-1 .text-red-200} 
+[When](#){: .p-1 .text-red-200}
 I
-[action](#){: .p-1 .text-green-200 .fw-700} 
+[action](#){: .p-1 .text-green-200 .fw-700}
 the value
 >
 | key | Description | Examples |


### PR DESCRIPTION
For both `is` and `is not` I have added reference that `type` references the Terraform resource type as this is very useful to know and wasn't clear from the documentation. I've tidied up the descriptions around those too (not requiring "e.g" in the description when it's a separate column). Whilst doing this I also fixed two spelling mistakes and capitalised "Terraform" when referring to the program and not the command line.