### PR TITLE
Fixed a problem where resource names starting with 'data' was misinterpreted

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ junit-xml==1.9
 emoji==0.5.4
 lxml==4.5.0
 ddt==1.3.1
+pytest==5.4.1

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -406,4 +406,4 @@ class TerraformParser(object):
 
             return resource['address'].split('.')[0] == mode
 
-        raise TerraformComplianceInternalFailure('Invalid structure while checking for {}. ({})'.format(mode, resource))
+        return False

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -65,13 +65,13 @@ class TestTerraformParser(TestCase):
             'root_module': {
                 'resources': [
                     {
-                        'address': 'data_something'
+                        'address': 'data.something'
                     }
                 ]
             }
         }
         obj._parse_resources()
-        self.assertEqual(obj.data['data_something'], {'address': 'data_something'})
+        self.assertEqual(obj.data['data.something'], {'address': 'data.something'})
 
 
     @patch.object(TerraformParser, '_read_file', return_value={})
@@ -97,13 +97,13 @@ class TestTerraformParser(TestCase):
             'root_module': {
                 'resources': [
                     {
-                        'address': 'data_something'
+                        'address': 'data.something'
                     }
                 ]
             }
         }
         obj._parse_resources()
-        self.assertEqual(obj.data['data_something'], {'address': 'data_something'})
+        self.assertEqual(obj.data['data.something'], {'address': 'data.something'})
 
 
     @patch.object(TerraformParser, '_read_file', return_value={})
@@ -130,14 +130,14 @@ class TestTerraformParser(TestCase):
                 'child_modules': {
                     'resources': [
                         {
-                            'address': 'data_something'
+                            'address': 'data.something'
                         }
                     ]
                 }
             }
         }
         obj._parse_resources()
-        self.assertEqual(obj.data['data_something'], {'address': 'data_something'})
+        self.assertEqual(obj.data['data.something'], {'address': 'data.something'})
 
 
     @patch.object(TerraformParser, '_read_file', return_value={})
@@ -162,7 +162,8 @@ class TestTerraformParser(TestCase):
         obj = TerraformParser('somefile', parse_it=False)
         obj.raw['resource_changes'] = [
             {
-                'address': 'data_something',
+                'mode': 'data',
+                'address': 'data.something',
                 'change': {
                     'actions': ['update'],
                     'before': {
@@ -175,7 +176,7 @@ class TestTerraformParser(TestCase):
             }
         ]
         obj._parse_resources()
-        self.assertEqual(obj.data['data_something'], {'address': 'data_something', 'values': {'key': 'bar'}})
+        self.assertEqual(obj.data['data.something'], {'address': 'data.something', 'mode': 'data', 'values': {'key': 'bar'}})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
     def test_parse_resources_resources_exists_in_the_resource_changes_resource(self, *args):


### PR DESCRIPTION
This PR addresses the problem described in #257.

Resource addresses starting with `data` was causing a problem where it was misinterpreted as a `data` entity, even though they are native resources.