### PR TITLE
Enhancement: Add directory and branch support for -f parameter for remote git repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.2.4 (2020-06-03)
+* Add ability to reference a git repo by branch name and directory via `<repo>.git//<directory>?ref=<branch-name`. ([#218](https://github.com/eerkunt/terraform-compliance/issues/218))
+
 ## 1.2.3 (2020-05-25)
 * Fixed a crash where some module outputs could not be processed. ([#275](https://github.com/eerkunt/terraform-compliance/issues/275))
 

--- a/docs/pages/usage/index.md
+++ b/docs/pages/usage/index.md
@@ -70,6 +70,18 @@ or if the repository is a private repository ;
 The authentication to that git repository will be handled via your `~/.ssh/config`. If you are using a different
 ssh key for this repository then you also need to provide `-i` parameter to pointing your private key.
 
+New in `1.2.4`, a repository can be referenced by branch name and directory. This uses syntax similar to Terraform
+[Modules in Package Sub-directories](https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories).
+The reference must include `//` after `.git` and end with `?ref=<branch-name>` or `?ref=<tag>`.
+```
+[~] $ terraform-compliance -f git:ssh://github.com/user/repo.git//directory?ref=v1.0.0 ...
+```
+The directory is optional.
+```
+[~] $ terraform-compliance -f git:ssh://github.com/user/repo.git//?ref=staging ...
+```
+
+
 ### -p / --planfile
 {: .d-inline-block }
 REQUIRED

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -63,9 +63,27 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
 
     # A remote repository used here
     if args.features.startswith(('http', 'https', 'ssh')):
-        features_git_repo = args.features
-        args.features = mkdtemp()
+        # Default to master branch and full repository
+        if args.features.endswith('.git'):
+            features_git_repo = args.features
 
+        # Optionally allow for directory and branch
+        elif '.git//' in args.features and '?ref=' in args.features:
+            # Split on .git/
+            features_git_list = args.features.split('.git/', 1)
+            # Everything up to .git is the repository
+            features_git_repo = features_git_list[0] + '.git'
+
+            # Split the directory and branch ref
+            features_git_list = features_git_list[1].split('?ref=', 1)
+            features_git_dir = features_git_list[0]
+            features_git_branch = features_git_list[1]
+
+        else:  # invalid
+            raise ValueError("Bad feature directory:" + args.features)
+
+        # Clone repository
+        args.features = mkdtemp()
         Repo.clone_from(url=features_git_repo, to_path=args.features, env=ssh_cmd)
 
     features_directory = os.path.join(os.path.abspath(args.features))

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -66,6 +66,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
         # Default to master branch and full repository
         if args.features.endswith('.git'):
             features_git_repo = args.features
+            features_git_branch = 'master'
 
         # Optionally allow for directory and branch
         elif '.git//' in args.features and '?ref=' in args.features:
@@ -84,7 +85,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
 
         # Clone repository
         args.features = mkdtemp()
-        Repo.clone_from(url=features_git_repo, to_path=args.features, env=ssh_cmd)
+        Repo.clone_from(url=features_git_repo, to_path=args.features, env=ssh_cmd, depth=1, branch=features_git_branch)
 
     features_directory = os.path.join(os.path.abspath(args.features))
 

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -61,6 +61,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
     if args.ssh_key:
         ssh_cmd = {'GIT_SSH_COMMAND': 'ssh -l {} -i {}'.format('git', args.ssh_key)}
 
+    features_dir = '/'
     # A remote repository used here
     if args.features.startswith(('http', 'https', 'ssh')):
         # Default to master branch and full repository
@@ -77,7 +78,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
 
             # Split the directory and branch ref
             features_git_list = features_git_list[1].split('?ref=', 1)
-            features_git_dir = features_git_list[0]
+            features_dir = features_git_list[0]
             features_git_branch = features_git_list[1]
 
         else:  # invalid
@@ -87,7 +88,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
         args.features = mkdtemp()
         Repo.clone_from(url=features_git_repo, to_path=args.features, env=ssh_cmd, depth=1, branch=features_git_branch)
 
-    features_directory = os.path.join(os.path.abspath(args.features))
+    features_directory = os.path.join(os.path.abspath(args.features) + features_dir)
 
     commands = ['radish',
                 '--write-steps-once',


### PR DESCRIPTION
Completes #218 

Users may wish to reference a specific branch or directory in remote git repositories. This allows them to do this with syntax similar to Terraform [Modules in Package Sub-directories](https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories).

The reference must include `//` after `.git` and end with `?ref=<branch-name>` or `?ref=<tag>`.
```
[~] $ terraform-compliance -f git:ssh://github.com/user/repo.git//directory?ref=v1.0.0 ...
```
The directory is optional.
```
[~] $ terraform-compliance -f git:ssh://github.com/user/repo.git//?ref=staging ...
```

Note that commit hashes are not supported.