### PR TITLE
Small bugfix on seek_value_in_dict

### DIFF
--- a/docs/pages/bdd-references/then.md
+++ b/docs/pages/bdd-references/then.md
@@ -248,6 +248,8 @@ to
 This step requires fundamental knowledge about regular expressions due the pattern matching algorithm. It is highly
 recommended to check for your patterns in [regex101](https://regex101.com/) before you implement your tests.
 
+All values are compared with the regex. If the value referred by "it" on the plan is an iterable, then this step will fail if any element in the value fails the [condition](#){: .p-1 .text-green-200 .fw-700} match.
+
 > __Possible sentences :__
 >
 > ▪

--- a/docs/pages/bdd-references/then.md
+++ b/docs/pages/bdd-references/then.md
@@ -248,7 +248,7 @@ to
 This step requires fundamental knowledge about regular expressions due the pattern matching algorithm. It is highly
 recommended to check for your patterns in [regex101](https://regex101.com/) before you implement your tests.
 
-All values are compared with the regex. If the value referred by "it" on the plan is an iterable, then this step will fail if any element in the value fails the [condition](#){: .p-1 .text-green-200 .fw-700} match.
+All values are compared with the regex. If the value referred by "it" on the plan is a dictionary or list, this step will fail if any element in the value fails the [condition](#){: .p-1 .text-green-200 .fw-700} match.
 
 > __Possible sentences :__
 >

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -257,7 +257,7 @@ def search_regex_in_list(regex, target_list):
 
 def seek_value_in_dict(needle, haystack, address=None):
     findings = []
-    if isinstance(haystack, (str, int, bool, float)) and needle in haystack:
+    if isinstance(haystack, (str, int, bool, float)) and needle in str(haystack):
         findings.append(dict(values=needle, address=None))
 
     elif isinstance(haystack, dict):

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -257,7 +257,7 @@ def search_regex_in_list(regex, target_list):
 
 def seek_value_in_dict(needle, haystack, address=None):
     findings = []
-    if isinstance(haystack, (str, int, bool, float)) and needle in str(haystack):
+    if isinstance(haystack, (str, int, bool, float)) and str(needle) in str(haystack):
         findings.append(dict(values=needle, address=None))
 
     elif isinstance(haystack, dict):

--- a/terraform_compliance/steps/then/its_value_condition_match_the_search_regex.py
+++ b/terraform_compliance/steps/then/its_value_condition_match_the_search_regex.py
@@ -27,7 +27,7 @@ def its_value_condition_match_the_search_regex_regex(_step_obj, condition, searc
     regex_flags = re.IGNORECASE if case_insensitive else 0
     regex_flag_error_text = 'case insensitive' if case_insensitive else 'case sensitive'
 
-    if isinstance(values, (str, int, bool)) or values is None:
+    if isinstance(values, (str, int, bool, float)) or values is None:
         matches = re.match(regex, str(values), flags=regex_flags)
 
         if (condition == 'must' and matches is None) or (condition == "must not" and matches is not None):

--- a/tests/functional/test_issue-285/.expected
+++ b/tests/functional/test_issue-285/.expected
@@ -1,0 +1,1 @@
+Failure: the \(^AzureServices$\) regex could not found in azurerm_storage_account.example.

--- a/tests/functional/test_issue-285/.unexpected
+++ b/tests/functional/test_issue-285/.unexpected
@@ -1,0 +1,1 @@
+TypeError: argument of type 'bool' is not iterable

--- a/tests/functional/test_issue-285/main.tf
+++ b/tests/functional/test_issue-285/main.tf
@@ -1,0 +1,24 @@
+resource "azurerm_storage_account" "example" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  network_rules {
+    bypass                     = ["AzureServices", "Logging", "Metrics"]
+    default_action             = "Deny"
+    ip_rules                   = ["100.1.1.123/32"]
+  }
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+provider "azurerm" {
+   features {}
+}

--- a/tests/functional/test_issue-285/test.feature
+++ b/tests/functional/test_issue-285/test.feature
@@ -1,0 +1,6 @@
+Feature: Feature for issue #285
+	Scenario: Ensure 'Trusted Microsoft Services' is enabled for Storage Account access
+		Given I have azurerm_storage_account defined
+		Then it must contain network_rules
+		And it must contain bypass
+		And its value must contain the "(^AzureServices$)" regex


### PR DESCRIPTION
which prevents causing type errors attempting to iterate through a non-iterable.

Addresses issue #285 

Also added float to its_value_condition_match_the_search_regex.py, because it was included on other places and made sense. (not tested)