### PR TITLE
Live debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Generalized case-sensitivity tag to work on all steps. Centralized matching and seeking functions.
 * Jsonfiy the stash on creation to prevent bugs related to jsonification.
 * Added python version check for invalid Python versions. Minimum python version is set to 3.6.0
+* Added `--debug/-d` option
 
 ## 1.2.7 (2020-06-19)
 * Fixed faulty over restriction in [Then its singular value condition match the "search_regex" regex](https://terraform-compliance.com/pages/bdd-references/then.html#then-its-singular-value-condition-match-the-search-regex-regex).

--- a/docs/pages/usage/index.md
+++ b/docs/pages/usage/index.md
@@ -184,3 +184,23 @@ OPTIONAL
 
 This option will surpress the output of `Feature`, `Scenario` and `Steps`. Only the
 summary and the Failure messages will be shown - if applicable.
+
+### -d / --debug
+{: .d-inline-block }
+OPTIONAL
+{: .label .label-yellow}
+
+{: .d-inline-block }
+1.2.+
+{: .label .label-blue}
+
+This option will let you peek in the stash or run IPython on the current step.
+
+**Commands**
+- s: prints stash
+- d: opens Interactive Python.
+- h: prints commands
+
+In Python shell, context can be accessed via `step.context.stash`. Note that modifications to step object will carry over to the steps below.
+
+It is usually a better idea to inspect the stash *before* the step being debugged.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ddt==1.4.1
 pytest==5.4.3
 nose==1.3.7
 semver==2.10.2
+IPython==7.16.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ dependencies = [
     'lxml>=4.5.0',
     'emoji>=0.5.4',
     'mock>=3.0.5',
-    'semver>=2.10.2'
+    'semver>=2.10.2',
+    'IPython==7.16.1',
 ]
 
 setup(

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -96,7 +96,6 @@ def cli(arghandling=cli_arguments, argparser=ArgumentParser(prog=__app_name__,
     features_directory = os.path.join(os.path.abspath(args.features) + features_dir)
 
     commands = ['radish',
-                # '--inspect-after-failure',
                 '--write-steps-once',
                 features_directory,
                 '--basedir', steps_directory,

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -31,8 +31,9 @@ print('{} v{} initiated\n'.format(__app_name__, Defaults().yellow(__version__)))
 class ArgHandling(object):
     pass
 
+cli_arguments = ArgHandling() # make this global?
 
-def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
+def cli(arghandling=cli_arguments, argparser=ArgumentParser(prog=__app_name__,
                                                             description='BDD Test Framework for Hashicorp terraform')):
     args = arghandling
     parser = argparser
@@ -50,6 +51,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
                         help='Do not output any scenarios, just write results or failures', required=False)
     parser.add_argument('--identity', '-i', dest='ssh_key', metavar='ssh private key', type=str, nargs='?',
                         help='SSH Private key that will be use on git authentication.', required=False)
+    parser.add_argument('--debug', '-d', dest='debug', action='store_true', help='Turns on debugging mode', required=False)
 
     parser.add_argument('--version', '-v', action='version', version=__version__)
 
@@ -94,6 +96,7 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
     features_directory = os.path.join(os.path.abspath(args.features) + features_dir)
 
     commands = ['radish',
+                # '--inspect-after-failure',
                 '--write-steps-once',
                 features_directory,
                 '--basedir', steps_directory,

--- a/terraform_compliance/steps/terrain.py
+++ b/terraform_compliance/steps/terrain.py
@@ -1,5 +1,6 @@
 import curses
 import json
+from IPython import embed
 from radish import before, after, world
 from terraform_compliance.extensions.terraform import TerraformParser
 from terraform_compliance.main import cli_arguments
@@ -17,8 +18,6 @@ def wait_for_user_input(step):
         return
 
     cmd = 'cmd'
-
-    # pythonify this later
     while cmd != '':
         try:
             cmd = input(">> Press enter to continue")
@@ -27,23 +26,16 @@ def wait_for_user_input(step):
             return
         
         if cmd == 'd':
-            try:
-                from IPython import embed
-            except ImportError as e:
-                raise RadishError(
-                'if you want to use the failure inspector extension you have to "pip install radish-bdd[ipython-debugger]"'
-                )
-
             embed()
         elif cmd == 's':
-            # print(step.context.stash)
             print(json.dumps(step.context.stash, indent=4))
         elif cmd != '':
             print(
                 """
 Commands
 - s: prints stash
-- d: opens interactive python
+- d: opens Interactive Python
+- h: prints commands
                 """
             )
 

--- a/terraform_compliance/steps/terrain.py
+++ b/terraform_compliance/steps/terrain.py
@@ -1,7 +1,50 @@
-from radish import before, world
+import curses
+import json
+from radish import before, after, world
 from terraform_compliance.extensions.terraform import TerraformParser
-
+from terraform_compliance.main import cli_arguments
 
 @before.each_feature
 def load_terraform_data(feature):
     world.config.terraform = TerraformParser(world.config.user_data['plan_file'])
+
+
+@after.each_step
+def wait_for_user_input(step):
+    global cli_arguments
+
+    if not cli_arguments.debug:
+        return
+
+    cmd = 'cmd'
+
+    # pythonify this later
+    while cmd != '':
+        try:
+            cmd = input(">> Press enter to continue")
+        except EOFError:
+            print()
+            return
+        
+        if cmd == 'd':
+            try:
+                from IPython import embed
+            except ImportError as e:
+                raise RadishError(
+                'if you want to use the failure inspector extension you have to "pip install radish-bdd[ipython-debugger]"'
+                )
+
+            embed()
+        elif cmd == 's':
+            # print(step.context.stash)
+            print(json.dumps(step.context.stash, indent=4))
+        elif cmd != '':
+            print(
+                """
+Commands
+- s: prints stash
+- d: opens interactive python
+                """
+            )
+
+


### PR DESCRIPTION
### -d / --debug
This option will let you peek in the stash or run IPython on the current step.
**Commands**
- s: prints stash
- d: opens Interactive Python.
- h: prints commands
In Python shell, context can be accessed via `step.context.stash`. Note that modifications to step object will carry over to the steps below.
It is usually a better idea to inspect the stash *before* the step being debugged.

### Notes
- I was hoping to have an interactive and colorful way of parsing the stash, but this was the solution I could come up with. 
- Curses can be added to run the commands with a single click instead of pressing enter afterwards. However, I would need help to prevent curses from clearing the screen. (Which I is probably not easy)
