### PR TITLE
Nested structure problem fix

### DIFF
--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -142,7 +142,16 @@ class TerraformParser(object):
         # Resources
         self.configuration['resources'] = {}
 
-        for resource in self.raw.get('configuration', {}).get('root_module', {}).get('resources', []):
+        resources = []
+
+        # root resources
+        resources = self.raw.get('configuration', {}).get('root_module', {}).get('resources', [])
+
+        # Append module resources
+        for module in seek_key_in_dict(self.raw.get('configuration', {}).get('root_module', {}).get("module_calls", {}), "module"):
+            resources += module.get('module',{}).get("resources", [])
+
+        for resource in resources:
             if self.is_type(resource, 'data'):
                 self.data[resource['address']] = resource
             else:

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -142,12 +142,11 @@ class TerraformParser(object):
         # Resources
         self.configuration['resources'] = {}
 
-        for findings in seek_key_in_dict(self.raw.get('configuration', {}).get('root_module', {}), 'resources'):
-            for resource in findings.get('resources', []):
-                if self.is_type(resource, 'data'):
-                    self.data[resource['address']] = resource
-                else:
-                    self.configuration['resources'][resource['address']] = resource
+        for resource in self.raw.get('configuration', {}).get('root_module', {}).get('resources', []):
+            if self.is_type(resource, 'data'):
+                self.data[resource['address']] = resource
+            else:
+                self.configuration['resources'][resource['address']] = resource
 
         # Variables
         self.configuration['variables'] = {}

--- a/tests/terraform_compliance/common/test_helper.py
+++ b/tests/terraform_compliance/common/test_helper.py
@@ -90,6 +90,13 @@ class TestHelperFunctions(TestCase):
 
         self.assertEqual(seek_key_in_dict(dictionary, search_key), expected)
 
+    def test_seek_in_dict_for_root_and_non_root_values(self):
+        dictionary = dict(a=dict(b=dict(something=dict(test=[]))), something=["b"])
+        search_key = "something"
+        expected = [{'something':{'test': []}}, {'something':['b']}]
+
+        self.assertEqual(seek_key_in_dict(dictionary, search_key), expected)
+
     def test_seek_in_dict_finding_values_in_non_dicts_on_root(self):
         dictionary = 'something_else'
         search_key = 'something_else'

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -262,7 +262,28 @@ class TestTerraformParser(TestCase):
         self.assertEqual(obj.configuration['providers'], {'some_provider': 'some_provider_data'})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
-    def test_parse_configurations_nested_resources(self, *args):
+    def test_parse_configurations_module_resources(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['configuration'] = {
+            'root_module': {
+                'module_calls': {
+                    'a_module':{
+                        'module': {
+                            'resources': [
+                                {
+                                    'address': 'something'
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        obj._parse_configurations()
+        self.assertEqual(obj.configuration['resources']['something'], {'address': 'something'})
+
+    @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_configurations_ignore_nested_resources(self, *args):
         obj = TerraformParser('somefile', parse_it=False)
         obj.raw['configuration'] = {
             'root_module': {

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -261,6 +261,36 @@ class TestTerraformParser(TestCase):
         obj._parse_configurations()
         self.assertEqual(obj.configuration['providers'], {'some_provider': 'some_provider_data'})
 
+    @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_configurations_nested_resources(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['configuration'] = {
+            'root_module': {
+                'module_calls': {
+                    'a_module':{
+                        'expressions': {
+                            'cluster_role_rules': {
+                                'constant_values': [
+                                    {
+                                        "resources": [
+                                            "namespaces",
+                                            "pods"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                'resources': [
+                    {
+                        'address': 'something'
+                    }
+                ]
+            }
+        }
+        obj._parse_configurations()
+        self.assertEqual(obj.configuration['resources']['something'], {'address': 'something'})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
     def test_mount_resources_with_ref_type(self, *args):


### PR DESCRIPTION
Based on the failures we were having and the file unexpectedly trying to process random nested structures that happened to be named "resources" I have attempted to address this.

I used the information at [JSON Output Format](https://www.terraform.io/docs/internals/json-format.html#configuration-representation) to determine that the "resources" should be directly below the "root_module" in the configuration. Please let me know if this is an incorrect assumption.