### PR TITLE
Faster mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Improved mounting references to accomodate large plan files. ([#346](https://github.com/eerkunt/terraform-compliance/pull/346))
 
 ## 1.3.0 (2020-07-31)
 * Added cache capability and optimised the resource mounting a bit since it might trigger OOM kernel signalling and can be killed unexpectedly.

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -80,13 +80,8 @@ class Match(object):
         return re.match(*args, **kwargs, flags=regex_flag)
 
     
-    def seek_key_in_dict(self, haystack, needle):
-        haystacks = set()
-        return self.seek_key_in_dict_helper(haystack, needle, haystacks)
-
-
     # seek key in dict but with case_sensitivity
-    def seek_key_in_dict_helper(self, haystack, needle, haystacks):
+    def seek_key_in_dict(self, haystack, needle):
         '''
         Searches needle in haystack ( could be dict, list, list of dicts, nested dicts, etc. ) and returns all findings
         as a list
@@ -95,24 +90,17 @@ class Match(object):
         :param needle: search key
         :return: list of found keys & values
         '''
-
-        if id(haystack) in haystacks:
-            return []
-        
-        haystacks.add(id(haystack))
-
-
         found = list()
         if isinstance(haystack, dict):
             for key, value in haystack.items():
                 if self.equals(key, needle):
                     found.append({key: value})
                 else:
-                    found.extend(self.seek_key_in_dict_helper(value, needle, haystacks))
+                    found.extend(self.seek_key_in_dict(value, needle))
 
         elif isinstance(haystack, list):
             for value in haystack:
-                found.extend(self.seek_key_in_dict_helper(value, needle, haystacks))
+                found.extend(self.seek_key_in_dict(value, needle))
 
         else:
             return []
@@ -122,18 +110,6 @@ class Match(object):
     # ...
     # needle == value
     def seek_value_in_dict(self, needle, haystack, address=None):
-        haystacks = set()
-        return self.seek_value_in_dict_helper(needle, haystack, haystacks, address)
-
-
-    def seek_value_in_dict_helper(self, needle, haystack, haystacks, address=None):
-
-        if id(haystack) in haystacks:
-            return list()
-        
-        haystacks.add(id(haystack))
-
-
         findings = []
         # if isinstance(haystack, (str, int, bool, float)) and str(needle) in str(haystack):  # this shouldn't be in but == instead
         #     findings.append(dict(values=needle, address=None))
@@ -145,7 +121,7 @@ class Match(object):
 
             for key, value in haystack.items():
                 if isinstance(value, (dict, list)):
-                    findings.extend(self.seek_value_in_dict_helper(needle, value, haystacks))
+                    findings.extend(self.seek_value_in_dict(needle, value))
                 
                 elif isinstance(value, (str, bool, int, float)) and self.equals(needle, value):
                     findings.append(dict(values=needle, address=address))
@@ -158,7 +134,7 @@ class Match(object):
             # Otherwise, there are more stuff, so go recursive
             else:
                 for value in haystack:
-                    findings.extend(self.seek_value_in_dict_helper(needle, value, haystacks))
+                    findings.extend(self.seek_value_in_dict(needle, value))
 
         return findings
 
@@ -167,11 +143,6 @@ class Match(object):
     # case sensitivity overwrites regex (if case insensitive, there is always re.IGNORECASE)
         # this's admittedly weird but convention/backwards compatibility...
     def seek_regex_key_in_dict_values(self, haystack, key_name, needle, key_matched=None):
-        haystacks = set()
-        return self.seek_regex_key_in_dict_values_helper(haystack, key_name, needle, haystacks, key_matched)
-
-
-    def seek_regex_key_in_dict_values_helper(self, haystack, key_name, needle, haystacks, key_matched=None):
         '''
         Searches needle in haystack ( could be dict, list, list of dicts, nested dicts, etc. ) and returns all findings
         as a list. The only difference from seek_key_in_dict is, we are assuming needle is in regex format here and we
@@ -183,12 +154,6 @@ class Match(object):
         :param key_matched: Internal use
         :return: list of found keys & values
         '''
-        if id(haystack) in haystacks:
-            return list()
-        
-        haystacks.add(id(haystack))
-
-
         regex = r'^{}$'.format(needle)
         found = list()
         if isinstance(haystack, dict):
@@ -203,21 +168,21 @@ class Match(object):
                         if matches is not None:
                             found.append(matches.group(0))
                         else:
-                            found.extend(self.seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, True))
+                            found.extend(self.seek_regex_key_in_dict_values(value, key_name, needle, True))
 
                     elif isinstance(value, dict):
-                        found.extend(self.seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, True))
+                        found.extend(self.seek_regex_key_in_dict_values(value, key_name, needle, True))
 
                     elif isinstance(value, list):
                         for v in value:
-                            found.extend(self.seek_regex_key_in_dict_values_helper(v, key_name, needle, haystacks, True))
+                            found.extend(self.seek_regex_key_in_dict_values(v, key_name, needle, True))
 
                 else:
-                    found.extend(self.seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, key_matched))
+                    found.extend(self.seek_regex_key_in_dict_values(value, key_name, needle, key_matched))
 
         elif isinstance(haystack, list):
             for value in haystack:
-                found.extend(self.seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, key_matched))
+                found.extend(self.seek_regex_key_in_dict_values(value, key_name, needle, key_matched))
 
         else:
             return []
@@ -297,11 +262,6 @@ def convert_resource_type(resource_type):
 
 
 def seek_key_in_dict(haystack, needle):
-    haystacks = set()
-    return seek_key_in_dict_helper(haystack, needle, haystacks)
-
-def seek_key_in_dict_helper(haystack, needle, haystacks):
-
     '''
     Searches needle in haystack ( could be dict, list, list of dicts, nested dicts, etc. ) and returns all findings
     as a list
@@ -310,24 +270,17 @@ def seek_key_in_dict_helper(haystack, needle, haystacks):
     :param needle: search key
     :return: list of found keys & values
     '''
-
-    if id(haystack) in haystacks:
-        return []
-    
-    haystacks.add(id(haystack))
-
-
     found = list()
     if isinstance(haystack, dict):
         for key, value in haystack.items():
             if key.lower() == needle.lower():
                 found.append({key: value})
             else:
-                found.extend(seek_key_in_dict_helper(value, needle, haystacks))
+                found.extend(seek_key_in_dict(value, needle))
 
     elif isinstance(haystack, list):
         for value in haystack:
-            found.extend(seek_key_in_dict_helper(value, needle, haystacks))
+            found.extend(seek_key_in_dict(value, needle))
 
     else:
         return []
@@ -336,11 +289,6 @@ def seek_key_in_dict_helper(haystack, needle, haystacks):
 
 
 def seek_regex_key_in_dict_values(haystack, key_name, needle, key_matched=None):
-    haystacks = set()
-    return seek_regex_key_in_dict_values_helper(haystack, key_name, needle, haystacks, key_matched)
-
-
-def seek_regex_key_in_dict_values_helper(haystack, key_name, needle, haystacks, key_matched=None):
     '''
     Searches needle in haystack ( could be dict, list, list of dicts, nested dicts, etc. ) and returns all findings
     as a list. The only difference from seek_key_in_dict is, we are assuming needle is in regex format here and we
@@ -352,12 +300,6 @@ def seek_regex_key_in_dict_values_helper(haystack, key_name, needle, haystacks, 
     :param key_matched: Internal use
     :return: list of found keys & values
     '''
-    if id(haystack) in haystacks:
-        return list()
-    
-    haystacks.add(id(haystack))
-
-
     regex = r'^{}$'.format(needle)
     found = list()
     if isinstance(haystack, dict):
@@ -372,21 +314,21 @@ def seek_regex_key_in_dict_values_helper(haystack, key_name, needle, haystacks, 
                     if matches is not None:
                         found.append(matches.group(0))
                     else:
-                        found.extend(seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, True))
+                        found.extend(seek_regex_key_in_dict_values(value, key_name, needle, True))
 
                 elif isinstance(value, dict):
-                    found.extend(seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, True))
+                    found.extend(seek_regex_key_in_dict_values(value, key_name, needle, True))
 
                 elif isinstance(value, list):
                     for v in value:
-                        found.extend(seek_regex_key_in_dict_values_helper(v, key_name, needle, haystacks, True))
+                        found.extend(seek_regex_key_in_dict_values(v, key_name, needle, True))
 
             else:
-                found.extend(seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, key_matched))
+                found.extend(seek_regex_key_in_dict_values(value, key_name, needle, key_matched))
 
     elif isinstance(haystack, list):
         for value in haystack:
-            found.extend(seek_regex_key_in_dict_values_helper(value, key_name, needle, haystacks, key_matched))
+            found.extend(seek_regex_key_in_dict_values(value, key_name, needle, key_matched))
 
     else:
         return []
@@ -439,31 +381,18 @@ def jsonify(string):
         return string
 
 
-# use helpers first, move to decorators later
-# maybe use an implicit variable to keep track of if you're the first call or a child call
-
 def recursive_jsonify(haystack):
-    haystacks = set()
-    return recursive_jsonify_helper(haystack, haystacks)
-
-
-def recursive_jsonify_helper(haystack, haystacks):
-    if id(haystack) in haystacks:
-        return haystack
-    
-    haystacks.add(id(haystack))
-
     if isinstance(haystack, str):
         haystack = jsonify(haystack)
         if isinstance(haystack, (list, dict)):
-            return recursive_jsonify_helper(haystack, haystacks)
+            return recursive_jsonify(haystack)
         return haystack
 
     if isinstance(haystack, dict):
-        haystack = {key: recursive_jsonify_helper(value, haystacks) for key, value in haystack.items()}
+        haystack = {key: recursive_jsonify(value) for key, value in haystack.items()}
     
     if isinstance(haystack, list):
-        haystack = [recursive_jsonify_helper(value, haystacks) for value in haystack]
+        haystack = [recursive_jsonify(value) for value in haystack]
 
     return haystack
 

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -5,11 +5,6 @@ from copy import deepcopy
 from terraform_compliance.common.defaults import Defaults
 from terraform_compliance.extensions.cache import Cache
 
-class IdObject(object):
-    def __init__(self, num):
-        self.id = num
-
-
 class TerraformParser(object):
     def __init__(self, filename, parse_it=True):
         '''
@@ -244,7 +239,6 @@ class TerraformParser(object):
                     if target_resource not in self.resources or 'values' not in self.resources[target_resource]:
                         continue
 
-                    # resource = deepcopy(self.resources[source_resource]['values'])
                     resource = self.resources_raw[source_resource]['values']
                     resource[Defaults.mounted_ptr] = True
 
@@ -260,7 +254,6 @@ class TerraformParser(object):
                     if ref_type not in self.resources[target_resource]['values']:
                         self.resources[target_resource]['values'][ref_type] = []
                         self.resources[target_resource]['values'][ref_type].append(resource)
-                        # self.resources[target_resource]['values'][ref_type].append(IdObject(1))
                         self.resources[target_resource][Defaults.r_mount_ptr][parameter] = ref_type
                         self.resources[target_resource][Defaults.r_mount_addr_ptr][parameter] = source
                         target_set = set(self.resources[target_resource][Defaults.r_mount_addr_ptr_list])
@@ -268,7 +261,6 @@ class TerraformParser(object):
                         self.resources[target_resource][Defaults.r_mount_addr_ptr_list] = list(target_set | source_set)
                     else:
                         self.resources[target_resource]['values'][ref_type].append(resource)
-                        # self.resources[target_resource]['values'][ref_type].append(IdObject(1))
                         self.resources[target_resource][Defaults.r_mount_ptr][parameter] = ref_type
                         self.resources[target_resource][Defaults.r_mount_addr_ptr][parameter] = source
                         target_set = set(self.resources[target_resource][Defaults.r_mount_addr_ptr_list])
@@ -344,7 +336,7 @@ class TerraformParser(object):
                         ref_type = resource_type
 
                     for k, v in ref_list.items():
-                        v = flatten_list(v) # what??
+                        v = flatten_list(v)
 
                     # Mounting A->B
                     source_resources = self._find_resource_from_name(self.configuration['resources'][resource]['address'])

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -5,6 +5,11 @@ from copy import deepcopy
 from terraform_compliance.common.defaults import Defaults
 from terraform_compliance.extensions.cache import Cache
 
+class IdObject(object):
+    def __init__(self, num):
+        self.id = num
+
+
 class TerraformParser(object):
     def __init__(self, filename, parse_it=True):
         '''
@@ -239,7 +244,8 @@ class TerraformParser(object):
                     if target_resource not in self.resources or 'values' not in self.resources[target_resource]:
                         continue
 
-                    resource = deepcopy(self.resources[source_resource]['values'])
+                    # resource = deepcopy(self.resources[source_resource]['values'])
+                    resource = self.resources[source_resource]['values']
                     resource[Defaults.mounted_ptr] = True
 
                     if Defaults.r_mount_ptr not in self.resources[target_resource]:
@@ -254,6 +260,7 @@ class TerraformParser(object):
                     if ref_type not in self.resources[target_resource]['values']:
                         self.resources[target_resource]['values'][ref_type] = []
                         self.resources[target_resource]['values'][ref_type].append(resource)
+                        # self.resources[target_resource]['values'][ref_type].append(IdObject(1))
                         self.resources[target_resource][Defaults.r_mount_ptr][parameter] = ref_type
                         self.resources[target_resource][Defaults.r_mount_addr_ptr][parameter] = source
                         target_set = set(self.resources[target_resource][Defaults.r_mount_addr_ptr_list])
@@ -261,6 +268,7 @@ class TerraformParser(object):
                         self.resources[target_resource][Defaults.r_mount_addr_ptr_list] = list(target_set | source_set)
                     else:
                         self.resources[target_resource]['values'][ref_type].append(resource)
+                        # self.resources[target_resource]['values'][ref_type].append(IdObject(1))
                         self.resources[target_resource][Defaults.r_mount_ptr][parameter] = ref_type
                         self.resources[target_resource][Defaults.r_mount_addr_ptr][parameter] = source
                         target_set = set(self.resources[target_resource][Defaults.r_mount_addr_ptr_list])
@@ -336,7 +344,7 @@ class TerraformParser(object):
                         ref_type = resource_type
 
                     for k, v in ref_list.items():
-                        v = flatten_list(v)
+                        v = flatten_list(v) # what??
 
                     # Mounting A->B
                     source_resources = self._find_resource_from_name(self.configuration['resources'][resource]['address'])

--- a/terraform_compliance/extensions/terraform.py
+++ b/terraform_compliance/extensions/terraform.py
@@ -245,7 +245,7 @@ class TerraformParser(object):
                         continue
 
                     # resource = deepcopy(self.resources[source_resource]['values'])
-                    resource = self.resources[source_resource]['values']
+                    resource = self.resources_raw[source_resource]['values']
                     resource[Defaults.mounted_ptr] = True
 
                     if Defaults.r_mount_ptr not in self.resources[target_resource]:

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -5,6 +5,7 @@ from mock import patch
 from ddt import ddt, data
 from copy import deepcopy
 
+
 @ddt
 class TestTerraformParser(TestCase):
 

--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -3,7 +3,7 @@ from terraform_compliance.extensions.terraform import TerraformParser, seek_key_
 from tests.mocks import MockedData
 from mock import patch
 from ddt import ddt, data
-
+from copy import deepcopy
 
 @ddt
 class TestTerraformParser(TestCase):
@@ -331,6 +331,7 @@ class TestTerraformParser(TestCase):
                 }
             }
         }
+        obj.resources_raw = deepcopy(obj.resources)
         obj._mount_resources([source], {'some_key': [target]}, ref_type)
         self.assertEqual(['a', {'some_key': 'some_value', 'terraform-compliance.mounted': True}], obj.resources[target]['values'][ref_type])
 
@@ -350,6 +351,7 @@ class TestTerraformParser(TestCase):
                 }
             }
         }
+        obj.resources_raw = deepcopy(obj.resources)
         obj._mount_resources([source], {'some_key': [target]}, ref_type)
         self.assertEqual([{'some_key': 'some_value', 'terraform-compliance.mounted': True}], obj.resources[target]['values'][ref_type])
 
@@ -366,6 +368,7 @@ class TestTerraformParser(TestCase):
             source: {
             }
         }
+        obj.resources_raw = deepcopy(obj.resources)
         obj._mount_resources([source], [target], ref_type)
         self.assertEqual({}, obj.resources[target]['values'])
 


### PR DESCRIPTION
Large plan files with lots of references may take too much time to mount.
Following is an attempt to reduce it. (Processing my plan file went from taking 90 seconds to 4 seconds)

Using `raw_resources` instead of `resources` to prevent having too much information within the resources. (i.e. discard nested mountings and cycle references)

I believe cycle referencing shouldn't be a problem. Older versions don't seem to fully support it, so I won't either. [Example](https://github.com/eerkunt/terraform-compliance/compare/master...Kudbettin:slow_mounting) of how cycle references could be handled. (Changes the application behavior a bit.)