### PR TITLE
Replace the null byte in failure traceback to prevent XML dump from breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+* Fixed an issue where the null character in step definition break --junit-xml dump. ([#347](https://github.com/eerkunt/terraform-compliance/pull/347))
+
 ## 1.3.1 (2020-08-12)
 * Improved mounting references to accomodate large plan files. ([#346](https://github.com/eerkunt/terraform-compliance/pull/346))
 
@@ -11,7 +14,6 @@
 
 ## 1.2.11 (2020-07-20)
 * Fixed an issue where [When it has something](https://terraform-compliance.com/pages/bdd-references/when.html#when-it-has-something) formats the search value incorrectly. ([#330](https://github.com/eerkunt/terraform-compliance/pull/330))
-
 
 ## 1.2.10 (2020-07-15)
 * Fixed `Then it must contain` to properly drill down and split into multiple resources if need be. ([#327](https://github.com/eerkunt/terraform-compliance/pull/327))

--- a/terraform_compliance/common/error_handling.py
+++ b/terraform_compliance/common/error_handling.py
@@ -84,4 +84,4 @@ class Error(Exception):
                 step.failure = WrapperError(self.exception('\r{}'.format(' '*len(self.exception_name))))
 
         if self.message:
-            self.step_obj.failure.traceback = '{}: {}'.format(self.exception_name, '\n'.join(self.message))
+            self.step_obj.failure.traceback = '{}: {}'.format(self.exception_name, '\n'.join(self.message)).replace('\x00', '\\x00') 


### PR DESCRIPTION
Fixed an issue where the null character in step definition is breaking `--junit-xml` dump.

Note that non '\x00' chars that are not XML compatible could still break the flag `--junit-xml`. However, I'm 70% sure terraform doesn't let you use XML incompatible characters, so it should be enough to replace the ones we provide.

Addresses #345 