### PR TITLE
Update error_handling.py for x08 character

### DIFF
--- a/terraform_compliance/common/error_handling.py
+++ b/terraform_compliance/common/error_handling.py
@@ -97,4 +97,4 @@ class Error(Exception):
                 step.failure = WrapperError(self.exception('\r{}'.format(' '*len(self.exception_name))))
 
         if self.message:
-            self.step_obj.failure.traceback = '{}: {}'.format(self.exception_name, '\n'.join(self.message)).replace('\x00', '\\x00') 
+            self.step_obj.failure.traceback = '{}: {}'.format(self.exception_name, '\n'.join(self.message)).replace('\x00', '\\x00').replace('\x08', '\\x08')


### PR DESCRIPTION
Clean up x08 character which is breaking JUnit XML conversion during provider version_constraint checks (character is present on back of provider name string).